### PR TITLE
Nonce address fix

### DIFF
--- a/system-contracts/contracts/ContractDeployer.sol
+++ b/system-contracts/contracts/ContractDeployer.sol
@@ -187,7 +187,7 @@ contract ContractDeployer is IContractDeployer, ISystemContract {
         // Subtract 1 for EOA since the nonce has already been incremented for this transaction
         uint256 senderNonce = msg.sender == tx.origin
             ? NONCE_HOLDER_SYSTEM_CONTRACT.getMinNonce(msg.sender) - 1
-            : NONCE_HOLDER_SYSTEM_CONTRACT.incrementDeploymentNonce(msg.sender);
+            : NONCE_HOLDER_SYSTEM_CONTRACT.incrementDeploymentNonce(msg.sender) + 1;
         address newAddress = Utils.getNewAddressCreateEVM(msg.sender, senderNonce);
         _evmDeployOnAddress(newAddress, _initCode);
         return newAddress;

--- a/system-contracts/contracts/EvmInterpreter.template.yul
+++ b/system-contracts/contracts/EvmInterpreter.template.yul
@@ -152,7 +152,7 @@ object "EVMInterpreter" {
             // segment of memory.
             getDeployedBytecode()
 
-            pop(warmAddress(address()))
+            pop($llvm_AlwaysInline_llvm$_warmAddress(address()))
 
             let returnOffset, returnLen := $llvm_NoInline_llvm$_simulate(isCallerEVM, evmGasLeft, isStatic)
             return(returnOffset, returnLen)

--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -823,12 +823,13 @@ function getEVMGas() -> evmGas {
     let _gas := gas()
     let requiredGas := add(EVM_GAS_STIPEND(), OVERHEAD())
 
-    if lt(sub(_gas,shl(30,1)), requiredGas) {
-        // This cheks if enough zkevm gas was provided, we are substracting 2^30 since that's the stipend, 
-        // and we need to make sure that the gas provided over that is enough for security reasons
-        revert(0, 0)
+    switch lt(_gas, requiredGas)
+    case 1 {
+        evmGas := 0
     }
-    evmGas := div(sub(_gas, requiredGas), GAS_DIVISOR())
+    default {
+        evmGas := div(sub(_gas, requiredGas), GAS_DIVISOR())
+    }
 }
 
 function _getZkEVMGas(_evmGas) -> zkevmGas {

--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -596,6 +596,19 @@ function warmSlot(key,currentValue) -> isWarm, originalValue {
     originalValue := mload(32)
 }
 
+function MAX_SYSTEM_CONTRACT_ADDR() -> ret {
+    ret := 0x000000000000000000000000000000000000ffff
+}
+
+/// @dev Checks whether an address is an EOA (i.e. has not code deployed on it)
+/// @param addr The address to check
+function isEOA(addr) -> ret {
+    ret := 0
+    if gt(addr, MAX_SYSTEM_CONTRACT_ADDR()) {
+        ret := iszero(_getRawCodeHash(addr))
+    }
+}
+
 function getNewAddress(addr) -> newAddr {
     let digest, nonce, addressEncoded, nonceEncoded, nonceEncodedLength, listLength, listLengthEconded
 
@@ -1279,7 +1292,17 @@ function genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, 
 
     _popEVMFrame()
 
-    incrementNonce(address())
+    switch result
+    case 1 {
+        incrementNonce(address())
+    }
+    default {
+        switch isEOA(address())
+        case 1 {
+            incrementNonce(address())
+        }
+        default {}
+    }
 
     let back
 

--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -670,7 +670,7 @@ function addGasIfEvmRevert(isCallerEVM,offset,size,evmGasLeft) -> newOffset,newS
     }
 }
 
-function warmAddress(addr) -> isWarm {
+function $llvm_AlwaysInline_llvm$_warmAddress(addr) -> isWarm {
     // TODO: Unhardcode this selector 0x8db2ba78
     mstore8(0, 0x8d)
     mstore8(1, 0xb2)
@@ -877,7 +877,7 @@ function performStaticCall(oldSp,evmGasLeft) -> extraCost, sp {
     checkMemOverflow(add(add(retOffset, retSize), MEM_OFFSET_INNER()), evmGasLeft)
 
     extraCost := 0
-    if iszero(warmAddress(addr)) {
+    if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
         extraCost := 2500
     }
 
@@ -1001,7 +1001,7 @@ function performCall(oldSp, evmGasLeft, isStatic) -> extraCost, sp {
     // If value is not 0 and the address given points to an empty account, then value_to_empty_account_cost is 25000. An account is empty if its balance is 0, its nonce is 0 and it has no code.
 
     extraCost := 0
-    if iszero(warmAddress(addr)) {
+    if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
         extraCost := 2500
     }
 
@@ -1071,7 +1071,7 @@ function delegateCall(oldSp, oldIsStatic, evmGasLeft) -> sp, isStatic, extraCost
     }
 
     extraCost := 0
-    if iszero(warmAddress(addr)) {
+    if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
         extraCost := 2500
     }
 
@@ -1206,7 +1206,7 @@ function _fetchConstructorReturnGas() -> gasLeft {
 }
 
 function genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, evmGasLeft {
-    pop(warmAddress(addr))
+    pop($llvm_AlwaysInline_llvm$_warmAddress(addr))
 
     _eraseReturndataPointer()
 
@@ -1281,7 +1281,7 @@ function performExtCodeCopy(evmGas,oldSp) -> evmGasLeft, sp {
         mul(3, shr(5, add(len, 31))),
         expandMemory(add(dest, len))
     )
-    if iszero(warmAddress(addr)) {
+    if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
         dynamicGas := add(dynamicGas, 2500)
     }
     evmGasLeft := chargeGas(evmGasLeft, dynamicGas)

--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -148,6 +148,31 @@ function pushStackItem(sp, item, evmGasLeft) -> newSp {
     mstore(newSp, item)
 }
 
+function popStackItemWithoutCheck(sp) -> a, newSp {
+    a := mload(sp)
+    newSp := sub(sp, 0x20)
+}
+
+function pushStackItemWithoutCheck(sp, item) -> newSp {
+    newSp := add(sp, 0x20)
+    mstore(newSp, item)
+}
+
+function popStackCheck(sp, evmGasLeft, numInputs) {
+    if lt(sub(sp, mul(0x20, sub(numInputs, 1))), STACK_OFFSET()) {
+        revertWithGas(evmGasLeft)
+    }
+}
+
+function popPushStackCheck(sp, evmGasLeft, numInputs) {
+    let popCheck := lt(sub(sp, mul(0x20, sub(numInputs, 1))), STACK_OFFSET())
+    let pushOffset := sub(sp, mul(0x20, numInputs))
+    let pushCheck := or(gt(pushOffset, BYTECODE_OFFSET()), eq(pushOffset, BYTECODE_OFFSET()))
+    if or(popCheck, pushCheck) {
+        revertWithGas(evmGasLeft)
+    }
+}
+
 function getCodeAddress() -> addr {
     addr := verbatim_0i_1o("code_source")
 }
@@ -861,12 +886,13 @@ function _saveReturndataAfterZkEVMCall() {
 function performStaticCall(oldSp,evmGasLeft) -> extraCost, sp {
     let gasToPass,addr, argsOffset, argsSize, retOffset, retSize
 
-    gasToPass, sp := popStackItem(oldSp, evmGasLeft)
-    addr, sp := popStackItem(sp, evmGasLeft)
-    argsOffset, sp := popStackItem(sp, evmGasLeft)
-    argsSize, sp := popStackItem(sp, evmGasLeft)
-    retOffset, sp := popStackItem(sp, evmGasLeft)
-    retSize, sp := popStackItem(sp, evmGasLeft)
+    popStackCheck(oldSp, evmGasLeft, 6)
+    gasToPass, sp := popStackItemWithoutCheck(oldSp)
+    addr, sp := popStackItemWithoutCheck(sp)
+    argsOffset, sp := popStackItemWithoutCheck(sp)
+    argsSize, sp := popStackItemWithoutCheck(sp)
+    retOffset, sp := popStackItemWithoutCheck(sp)
+    retSize, sp := popStackItemWithoutCheck(sp)
 
     addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
 
@@ -983,13 +1009,14 @@ function _performCall(addr,gasToPass,value,argsOffset,argsSize,retOffset,retSize
 function performCall(oldSp, evmGasLeft, isStatic) -> extraCost, sp {
     let gasToPass,addr,value,argsOffset,argsSize,retOffset,retSize
 
-    gasToPass, sp := popStackItem(oldSp, evmGasLeft)
-    addr, sp := popStackItem(sp, evmGasLeft)
-    value, sp := popStackItem(sp, evmGasLeft)
-    argsOffset, sp := popStackItem(sp, evmGasLeft)
-    argsSize, sp := popStackItem(sp, evmGasLeft)
-    retOffset, sp := popStackItem(sp, evmGasLeft)
-    retSize, sp := popStackItem(sp, evmGasLeft)
+    popStackCheck(oldSp, evmGasLeft, 7)
+    gasToPass, sp := popStackItemWithoutCheck(oldSp)
+    addr, sp := popStackItemWithoutCheck(sp)
+    value, sp := popStackItemWithoutCheck(sp)
+    argsOffset, sp := popStackItemWithoutCheck(sp)
+    argsSize, sp := popStackItemWithoutCheck(sp)
+    retOffset, sp := popStackItemWithoutCheck(sp)
+    retSize, sp := popStackItemWithoutCheck(sp)
 
     addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
 
@@ -1051,12 +1078,13 @@ function delegateCall(oldSp, oldIsStatic, evmGasLeft) -> sp, isStatic, extraCost
     sp := oldSp
     isStatic := oldIsStatic
 
-    gasToPass, sp := popStackItem(sp, evmGasLeft)
-    addr, sp := popStackItem(sp, evmGasLeft)
-    argsOffset, sp := popStackItem(sp, evmGasLeft)
-    argsSize, sp := popStackItem(sp, evmGasLeft)
-    retOffset, sp := popStackItem(sp, evmGasLeft)
-    retSize, sp := popStackItem(sp, evmGasLeft)
+    popStackCheck(sp, evmGasLeft, 6)
+    gasToPass, sp := popStackItemWithoutCheck(sp)
+    addr, sp := popStackItemWithoutCheck(sp)
+    argsOffset, sp := popStackItemWithoutCheck(sp)
+    argsSize, sp := popStackItemWithoutCheck(sp)
+    retOffset, sp := popStackItemWithoutCheck(sp)
+    retSize, sp := popStackItemWithoutCheck(sp)
 
     // addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
 
@@ -1255,13 +1283,14 @@ function genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, 
 
     let back
 
-    back, sp := popStackItem(sp, evmGasLeft)
+    popStackCheck(sp, evmGasLeft, 4)
+    back, sp := popStackItemWithoutCheck(sp)
     mstore(sub(offset, 0x20), back)
-    back, sp := popStackItem(sp, evmGasLeft)
+    back, sp := popStackItemWithoutCheck(sp)
     mstore(sub(offset, 0x40), back)
-    back, sp := popStackItem(sp, evmGasLeft)
+    back, sp := popStackItemWithoutCheck(sp)
     mstore(sub(offset, 0x60), back)
-    back, sp := popStackItem(sp, evmGasLeft)
+    back, sp := popStackItemWithoutCheck(sp)
     mstore(sub(offset, 0x80), back)
 }
 
@@ -1269,10 +1298,11 @@ function performExtCodeCopy(evmGas,oldSp) -> evmGasLeft, sp {
     evmGasLeft := chargeGas(evmGas, 100)
 
     let addr, dest, offset, len
-    addr, sp := popStackItem(oldSp, evmGasLeft)
-    dest, sp := popStackItem(sp, evmGasLeft)
-    offset, sp := popStackItem(sp, evmGasLeft)
-    len, sp := popStackItem(sp, evmGasLeft)
+    popStackCheck(oldSp, evmGasLeft, 4)
+    addr, sp := popStackItemWithoutCheck(oldSp)
+    dest, sp := popStackItemWithoutCheck(sp)
+    offset, sp := popStackItemWithoutCheck(sp)
+    len, sp := popStackItemWithoutCheck(sp)
 
     // dynamicGas = 3 * minimum_word_size + memory_expansion_cost + address_access_cost
     // minimum_word_size = (size + 31) / 32
@@ -1312,9 +1342,10 @@ function performCreate(evmGas,oldSp,isStatic) -> evmGasLeft, sp {
 
     let value, offset, size
 
-    value, sp := popStackItem(oldSp, evmGasLeft)
-    offset, sp := popStackItem(sp, evmGasLeft)
-    size, sp := popStackItem(sp, evmGasLeft)
+    popStackCheck(oldSp, evmGasLeft, 3)
+    value, sp := popStackItemWithoutCheck(oldSp)
+    offset, sp := popStackItemWithoutCheck(sp)
+    size, sp := popStackItemWithoutCheck(sp)
 
     checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
 
@@ -1357,10 +1388,11 @@ function performCreate2(evmGas, oldSp, isStatic) -> evmGasLeft, sp, result, addr
 
     let value, offset, size, salt
 
-    value, sp := popStackItem(oldSp, evmGasLeft)
-    offset, sp := popStackItem(sp, evmGasLeft)
-    size, sp := popStackItem(sp, evmGasLeft)
-    salt, sp := popStackItem(sp, evmGasLeft)
+    popStackCheck(oldSp, evmGasLeft, 4)
+    value, sp := popStackItemWithoutCheck(oldSp)
+    offset, sp := popStackItemWithoutCheck(sp)
+    size, sp := popStackItemWithoutCheck(sp)
+    salt, sp := popStackItemWithoutCheck(sp)
 
     checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
 

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -21,90 +21,99 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, add(a, b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, add(a, b))
     }
     case 0x02 { // OP_MUL
         evmGasLeft := chargeGas(evmGasLeft, 5)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, mul(a, b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, mul(a, b))
     }
     case 0x03 { // OP_SUB
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, sub(a, b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, sub(a, b))
     }
     case 0x04 { // OP_DIV
         evmGasLeft := chargeGas(evmGasLeft, 5)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, div(a, b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, div(a, b))
     }
     case 0x05 { // OP_SDIV
         evmGasLeft := chargeGas(evmGasLeft, 5)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, sdiv(a, b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, sdiv(a, b))
     }
     case 0x06 { // OP_MOD
         evmGasLeft := chargeGas(evmGasLeft, 5)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, mod(a, b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, mod(a, b))
     }
     case 0x07 { // OP_SMOD
         evmGasLeft := chargeGas(evmGasLeft, 5)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, smod(a, b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, smod(a, b))
     }
     case 0x08 { // OP_ADDMOD
         evmGasLeft := chargeGas(evmGasLeft, 8)
 
         let a, b, N
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
-        N, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 3)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
+        N, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, addmod(a, b, N), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, addmod(a, b, N))
     }
     case 0x09 { // OP_MULMOD
         evmGasLeft := chargeGas(evmGasLeft, 8)
 
         let a, b, N
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
-        N, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 3)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
+        N, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItem(sp, mulmod(a, b, N), evmGasLeft)
     }
@@ -113,10 +122,11 @@ for { } true { } {
 
         let a, exponent
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        exponent, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        exponent, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, exp(a, exponent), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, exp(a, exponent))
 
         let to_charge := 0
         for {} gt(exponent,0) {} { // while exponent > 0
@@ -130,156 +140,172 @@ for { } true { } {
 
         let b, x
 
-        b, sp := popStackItem(sp, evmGasLeft)
-        x, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        b, sp := popStackItemWithoutCheck(sp)
+        x, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, signextend(b, x), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, signextend(b, x))
     }
     case 0x10 { // OP_LT
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, lt(a, b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, lt(a, b))
     }
     case 0x11 { // OP_GT
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, gt(a, b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, gt(a, b))
     }
     case 0x12 { // OP_SLT
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, slt(a, b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, slt(a, b))
     }
     case 0x13 { // OP_SGT
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, sgt(a, b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, sgt(a, b))
     }
     case 0x14 { // OP_EQ
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, eq(a, b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, eq(a, b))
     }
     case 0x15 { // OP_ISZERO
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let a
 
-        a, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 1)
+        a, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, iszero(a), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, iszero(a))
     }
     case 0x16 { // OP_AND
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, and(a,b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, and(a,b))
     }
     case 0x17 { // OP_OR
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, or(a,b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, or(a,b))
     }
     case 0x18 { // OP_XOR
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let a, b
 
-        a, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        a, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, xor(a, b), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, xor(a, b))
     }
     case 0x19 { // OP_NOT
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let a
 
-        a, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 1)
+        a, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, not(a), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, not(a))
     }
     case 0x1A { // OP_BYTE
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let i, x
 
-        i, sp := popStackItem(sp, evmGasLeft)
-        x, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        i, sp := popStackItemWithoutCheck(sp)
+        x, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, byte(i, x), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, byte(i, x))
     }
     case 0x1B { // OP_SHL
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let shift, value
 
-        shift, sp := popStackItem(sp, evmGasLeft)
-        value, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        shift, sp := popStackItemWithoutCheck(sp)
+        value, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, shl(shift, value), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, shl(shift, value))
     }
     case 0x1C { // OP_SHR
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let shift, value
 
-        shift, sp := popStackItem(sp, evmGasLeft)
-        value, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        shift, sp := popStackItemWithoutCheck(sp)
+        value, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, shr(shift, value), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, shr(shift, value))
     }
     case 0x1D { // OP_SAR
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let shift, value
 
-        shift, sp := popStackItem(sp, evmGasLeft)
-        value, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 2)
+        shift, sp := popStackItemWithoutCheck(sp)
+        value, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, sar(shift, value), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, sar(shift, value))
     }
     case 0x20 { // OP_KECCAK256
         evmGasLeft := chargeGas(evmGasLeft, 30)
 
         let offset, size
 
-        offset, sp := popStackItem(sp, evmGasLeft)
-        size, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 2)
+        offset, sp := popStackItemWithoutCheck(sp)
+        size, sp := popStackItemWithoutCheck(sp)
 
         checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflow(add(MEM_OFFSET_INNER(), add(offset, size)), evmGasLeft)
@@ -333,9 +359,10 @@ for { } true { } {
 
         let i
 
-        i, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 1)
+        i, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, calldataload(i), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, calldataload(i))
     }
     case 0x36 { // OP_CALLDATASIZE
         evmGasLeft := chargeGas(evmGasLeft, 2)
@@ -347,9 +374,10 @@ for { } true { } {
 
         let destOffset, offset, size
 
-        destOffset, sp := popStackItem(sp, evmGasLeft)
-        offset, sp := popStackItem(sp, evmGasLeft)
-        size, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 3)
+        destOffset, sp := popStackItemWithoutCheck(sp)
+        offset, sp := popStackItemWithoutCheck(sp)
+        size, sp := popStackItemWithoutCheck(sp)
 
         checkMultipleOverflow(offset,size,MEM_OFFSET_INNER(), evmGasLeft)
         checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER(), evmGasLeft)
@@ -383,9 +411,10 @@ for { } true { } {
 
         let dst, offset, len
 
-        dst, sp := popStackItem(sp, evmGasLeft)
-        offset, sp := popStackItem(sp, evmGasLeft)
-        len, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 3)
+        dst, sp := popStackItemWithoutCheck(sp)
+        offset, sp := popStackItemWithoutCheck(sp)
+        len, sp := popStackItemWithoutCheck(sp)
 
         // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
         // minimum_word_size = (size + 31) / 32
@@ -448,9 +477,10 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let dest, offset, len
-        dest, sp := popStackItem(sp, evmGasLeft)
-        offset, sp := popStackItem(sp, evmGasLeft)
-        len, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 3)
+        dest, sp := popStackItemWithoutCheck(sp)
+        offset, sp := popStackItemWithoutCheck(sp)
+        len, sp := popStackItemWithoutCheck(sp)
 
         // TODO: check if these conditions are met
         // The addition offset + size overflows.
@@ -489,9 +519,10 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 20)
 
         let blockNumber
-        blockNumber, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 1)
+        blockNumber, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, blockhash(blockNumber), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, blockhash(blockNumber))
     }
     case 0x41 { // OP_COINBASE
         evmGasLeft := chargeGas(evmGasLeft, 2)
@@ -552,8 +583,9 @@ for { } true { } {
 
         let offset, value
 
-        offset, sp := popStackItem(sp, evmGasLeft)
-        value, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 2)
+        offset, sp := popStackItemWithoutCheck(sp)
+        value, sp := popStackItemWithoutCheck(sp)
 
         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
         let expansionGas := expandMemory(add(offset, 32))
@@ -567,8 +599,9 @@ for { } true { } {
 
         let offset, value
 
-        offset, sp := popStackItem(sp, evmGasLeft)
-        value, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 2)
+        offset, sp := popStackItemWithoutCheck(sp)
+        value, sp := popStackItemWithoutCheck(sp)
 
         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
         let expansionGas := expandMemory(add(offset, 1))
@@ -609,8 +642,9 @@ for { } true { } {
 
         let key, value, gasSpent
 
-        key, sp := popStackItem(sp, evmGasLeft)
-        value, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 2)
+        key, sp := popStackItemWithoutCheck(sp)
+        value, sp := popStackItemWithoutCheck(sp)
 
         {
             // Here it is okay to read before we charge since we known anyway that
@@ -661,8 +695,9 @@ for { } true { } {
 
         let counter, b
 
-        counter, sp := popStackItem(sp, evmGasLeft)
-        b, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 2)
+        counter, sp := popStackItemWithoutCheck(sp)
+        b, sp := popStackItemWithoutCheck(sp)
 
         if iszero(b) {
             continue
@@ -704,9 +739,10 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 100)
 
         let key
-        key, sp := popStackItem(sp, evmGasLeft)
+        popPushStackCheck(sp, evmGasLeft, 1)
+        key, sp := popStackItemWithoutCheck(sp)
 
-        sp := pushStackItem(sp, tload(key), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, tload(key))
     }
     case 0x5D { // OP_TSTORE
         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -716,16 +752,18 @@ for { } true { } {
         }
 
         let key, value
-        key, sp := popStackItem(sp, evmGasLeft)
-        value, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 2)
+        key, sp := popStackItemWithoutCheck(sp)
+        value, sp := popStackItemWithoutCheck(sp)
 
         tstore(key, value)
     }
     case 0x5E { // OP_MCOPY
         let destOffset, offset, size
-        destOffset, sp := popStackItem(sp, evmGasLeft)
-        offset, sp := popStackItem(sp, evmGasLeft)
-        size, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 3)
+        destOffset, sp := popStackItemWithoutCheck(sp)
+        offset, sp := popStackItemWithoutCheck(sp)
+        size, sp := popStackItemWithoutCheck(sp)
 
         expandMemory(add(destOffset, size))
         expandMemory(add(offset, size))
@@ -1115,8 +1153,9 @@ for { } true { } {
         }
 
         let offset, size
-        offset, sp := popStackItem(sp, evmGasLeft)
-        size, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 2)
+        offset, sp := popStackItemWithoutCheck(sp)
+        size, sp := popStackItemWithoutCheck(sp)
 
         checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -1135,9 +1174,10 @@ for { } true { } {
         }
 
         let offset, size, topic1
-        offset, sp := popStackItem(sp, evmGasLeft)
-        size, sp := popStackItem(sp, evmGasLeft)
-        topic1, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 3)
+        offset, sp := popStackItemWithoutCheck(sp)
+        size, sp := popStackItemWithoutCheck(sp)
+        topic1, sp := popStackItemWithoutCheck(sp)
 
         checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -1156,8 +1196,9 @@ for { } true { } {
         }
 
         let offset, size
-        offset, sp := popStackItem(sp, evmGasLeft)
-        size, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 2)
+        offset, sp := popStackItemWithoutCheck(sp)
+        size, sp := popStackItemWithoutCheck(sp)
 
         checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -1169,8 +1210,9 @@ for { } true { } {
 
         {
             let topic1, topic2
-            topic1, sp := popStackItem(sp, evmGasLeft)
-            topic2, sp := popStackItem(sp, evmGasLeft)
+            popStackCheck(sp, evmGasLeft, 2)
+            topic1, sp := popStackItemWithoutCheck(sp)
+            topic2, sp := popStackItemWithoutCheck(sp)
             log2(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2)
         }
     }
@@ -1182,8 +1224,9 @@ for { } true { } {
         }
 
         let offset, size
-        offset, sp := popStackItem(sp, evmGasLeft)
-        size, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 2)
+        offset, sp := popStackItemWithoutCheck(sp)
+        size, sp := popStackItemWithoutCheck(sp)
 
         checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
 
@@ -1196,9 +1239,10 @@ for { } true { } {
 
         {
             let topic1, topic2, topic3
-            topic1, sp := popStackItem(sp, evmGasLeft)
-            topic2, sp := popStackItem(sp, evmGasLeft)
-            topic3, sp := popStackItem(sp, evmGasLeft)
+            popStackCheck(sp, evmGasLeft, 3)
+            topic1, sp := popStackItemWithoutCheck(sp)
+            topic2, sp := popStackItemWithoutCheck(sp)
+            topic3, sp := popStackItemWithoutCheck(sp)
             log3(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3)
         }     
     }
@@ -1210,8 +1254,9 @@ for { } true { } {
         }
 
         let offset, size
-        offset, sp := popStackItem(sp, evmGasLeft)
-        size, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 2)
+        offset, sp := popStackItemWithoutCheck(sp)
+        size, sp := popStackItemWithoutCheck(sp)
 
         checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -1223,10 +1268,11 @@ for { } true { } {
 
         {
             let topic1, topic2, topic3, topic4
-            topic1, sp := popStackItem(sp, evmGasLeft)
-            topic2, sp := popStackItem(sp, evmGasLeft)
-            topic3, sp := popStackItem(sp, evmGasLeft)
-            topic4, sp := popStackItem(sp, evmGasLeft)
+            popStackCheck(sp, evmGasLeft, 4)
+            topic1, sp := popStackItemWithoutCheck(sp)
+            topic2, sp := popStackItemWithoutCheck(sp)
+            topic3, sp := popStackItemWithoutCheck(sp)
+            topic4, sp := popStackItemWithoutCheck(sp)
             log4(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3, topic4)
         }     
     }
@@ -1247,8 +1293,9 @@ for { } true { } {
     case 0xF3 { // OP_RETURN
         let offset,size
 
-        offset, sp := popStackItem(sp, evmGasLeft)
-        size, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 2)
+        offset, sp := popStackItemWithoutCheck(sp)
+        size, sp := popStackItemWithoutCheck(sp)
 
         checkOverflow(offset,size, evmGasLeft)
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
@@ -1283,8 +1330,9 @@ for { } true { } {
     case 0xFD { // OP_REVERT
         let offset,size
 
-        offset, sp := popStackItem(sp, evmGasLeft)
-        size, sp := popStackItem(sp, evmGasLeft)
+        popStackCheck(sp, evmGasLeft, 2)
+        offset, sp := popStackItemWithoutCheck(sp)
+        size, sp := popStackItemWithoutCheck(sp)
 
         ensureAcceptableMemLocation(offset)
         ensureAcceptableMemLocation(size)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -307,7 +307,7 @@ for { } true { } {
         addr, sp := popStackItem(sp, evmGasLeft)
         addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
 
-        if iszero(warmAddress(addr)) {
+        if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
             evmGasLeft := chargeGas(evmGasLeft, 2500)
         }
 
@@ -422,7 +422,7 @@ for { } true { } {
         addr, sp := popStackItem(sp, evmGasLeft)
 
         addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
-        if iszero(warmAddress(addr)) {
+        if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
             evmGasLeft := chargeGas(evmGasLeft, 2500)
         }
 
@@ -475,7 +475,7 @@ for { } true { } {
         addr, sp := popStackItem(sp, evmGasLeft)
         addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
 
-        if iszero(warmAddress(addr)) {
+        if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
             evmGasLeft := chargeGas(evmGasLeft, 2500) 
         }
 

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -744,7 +744,7 @@ object "EVMInterpreter" {
             }
         }
         
-        function warmAddress(addr) -> isWarm {
+        function $llvm_AlwaysInline_llvm$_warmAddress(addr) -> isWarm {
             // TODO: Unhardcode this selector 0x8db2ba78
             mstore8(0, 0x8d)
             mstore8(1, 0xb2)
@@ -951,7 +951,7 @@ object "EVMInterpreter" {
             checkMemOverflow(add(add(retOffset, retSize), MEM_OFFSET_INNER()), evmGasLeft)
         
             extraCost := 0
-            if iszero(warmAddress(addr)) {
+            if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                 extraCost := 2500
             }
         
@@ -1075,7 +1075,7 @@ object "EVMInterpreter" {
             // If value is not 0 and the address given points to an empty account, then value_to_empty_account_cost is 25000. An account is empty if its balance is 0, its nonce is 0 and it has no code.
         
             extraCost := 0
-            if iszero(warmAddress(addr)) {
+            if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                 extraCost := 2500
             }
         
@@ -1145,7 +1145,7 @@ object "EVMInterpreter" {
             }
         
             extraCost := 0
-            if iszero(warmAddress(addr)) {
+            if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                 extraCost := 2500
             }
         
@@ -1280,7 +1280,7 @@ object "EVMInterpreter" {
         }
         
         function genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, evmGasLeft {
-            pop(warmAddress(addr))
+            pop($llvm_AlwaysInline_llvm$_warmAddress(addr))
         
             _eraseReturndataPointer()
         
@@ -1355,7 +1355,7 @@ object "EVMInterpreter" {
                 mul(3, shr(5, add(len, 31))),
                 expandMemory(add(dest, len))
             )
-            if iszero(warmAddress(addr)) {
+            if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                 dynamicGas := add(dynamicGas, 2500)
             }
             evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
@@ -1793,7 +1793,7 @@ object "EVMInterpreter" {
                     addr, sp := popStackItem(sp, evmGasLeft)
                     addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
-                    if iszero(warmAddress(addr)) {
+                    if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                         evmGasLeft := chargeGas(evmGasLeft, 2500)
                     }
             
@@ -1908,7 +1908,7 @@ object "EVMInterpreter" {
                     addr, sp := popStackItem(sp, evmGasLeft)
             
                     addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
-                    if iszero(warmAddress(addr)) {
+                    if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                         evmGasLeft := chargeGas(evmGasLeft, 2500)
                     }
             
@@ -1961,7 +1961,7 @@ object "EVMInterpreter" {
                     addr, sp := popStackItem(sp, evmGasLeft)
                     addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
-                    if iszero(warmAddress(addr)) {
+                    if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                         evmGasLeft := chargeGas(evmGasLeft, 2500) 
                     }
             
@@ -3495,7 +3495,7 @@ object "EVMInterpreter" {
                 }
             }
             
-            function warmAddress(addr) -> isWarm {
+            function $llvm_AlwaysInline_llvm$_warmAddress(addr) -> isWarm {
                 // TODO: Unhardcode this selector 0x8db2ba78
                 mstore8(0, 0x8d)
                 mstore8(1, 0xb2)
@@ -3702,7 +3702,7 @@ object "EVMInterpreter" {
                 checkMemOverflow(add(add(retOffset, retSize), MEM_OFFSET_INNER()), evmGasLeft)
             
                 extraCost := 0
-                if iszero(warmAddress(addr)) {
+                if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                     extraCost := 2500
                 }
             
@@ -3826,7 +3826,7 @@ object "EVMInterpreter" {
                 // If value is not 0 and the address given points to an empty account, then value_to_empty_account_cost is 25000. An account is empty if its balance is 0, its nonce is 0 and it has no code.
             
                 extraCost := 0
-                if iszero(warmAddress(addr)) {
+                if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                     extraCost := 2500
                 }
             
@@ -3896,7 +3896,7 @@ object "EVMInterpreter" {
                 }
             
                 extraCost := 0
-                if iszero(warmAddress(addr)) {
+                if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                     extraCost := 2500
                 }
             
@@ -4031,7 +4031,7 @@ object "EVMInterpreter" {
             }
             
             function genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, evmGasLeft {
-                pop(warmAddress(addr))
+                pop($llvm_AlwaysInline_llvm$_warmAddress(addr))
             
                 _eraseReturndataPointer()
             
@@ -4106,7 +4106,7 @@ object "EVMInterpreter" {
                     mul(3, shr(5, add(len, 31))),
                     expandMemory(add(dest, len))
                 )
-                if iszero(warmAddress(addr)) {
+                if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                     dynamicGas := add(dynamicGas, 2500)
                 }
                 evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
@@ -4544,7 +4544,7 @@ object "EVMInterpreter" {
                         addr, sp := popStackItem(sp, evmGasLeft)
                         addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
                 
-                        if iszero(warmAddress(addr)) {
+                        if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                             evmGasLeft := chargeGas(evmGasLeft, 2500)
                         }
                 
@@ -4659,7 +4659,7 @@ object "EVMInterpreter" {
                         addr, sp := popStackItem(sp, evmGasLeft)
                 
                         addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
-                        if iszero(warmAddress(addr)) {
+                        if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                             evmGasLeft := chargeGas(evmGasLeft, 2500)
                         }
                 
@@ -4712,7 +4712,7 @@ object "EVMInterpreter" {
                         addr, sp := popStackItem(sp, evmGasLeft)
                         addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
                 
-                        if iszero(warmAddress(addr)) {
+                        if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
                             evmGasLeft := chargeGas(evmGasLeft, 2500) 
                         }
                 
@@ -5570,7 +5570,7 @@ object "EVMInterpreter" {
             // segment of memory.
             getDeployedBytecode()
 
-            pop(warmAddress(address()))
+            pop($llvm_AlwaysInline_llvm$_warmAddress(address()))
 
             let returnOffset, returnLen := $llvm_NoInline_llvm$_simulate(isCallerEVM, evmGasLeft, isStatic)
             return(returnOffset, returnLen)

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -897,12 +897,13 @@ object "EVMInterpreter" {
             let _gas := gas()
             let requiredGas := add(EVM_GAS_STIPEND(), OVERHEAD())
         
-            if lt(sub(_gas,shl(30,1)), requiredGas) {
-                // This cheks if enough zkevm gas was provided, we are substracting 2^30 since that's the stipend, 
-                // and we need to make sure that the gas provided over that is enough for security reasons
-                revert(0, 0)
+            switch lt(_gas, requiredGas)
+            case 1 {
+                evmGas := 0
             }
-            evmGas := div(sub(_gas, requiredGas), GAS_DIVISOR())
+            default {
+                evmGas := div(sub(_gas, requiredGas), GAS_DIVISOR())
+            }
         }
         
         function _getZkEVMGas(_evmGas) -> zkevmGas {
@@ -3728,12 +3729,13 @@ object "EVMInterpreter" {
                 let _gas := gas()
                 let requiredGas := add(EVM_GAS_STIPEND(), OVERHEAD())
             
-                if lt(sub(_gas,shl(30,1)), requiredGas) {
-                    // This cheks if enough zkevm gas was provided, we are substracting 2^30 since that's the stipend, 
-                    // and we need to make sure that the gas provided over that is enough for security reasons
-                    revert(0, 0)
+                switch lt(_gas, requiredGas)
+                case 1 {
+                    evmGas := 0
                 }
-                evmGas := div(sub(_gas, requiredGas), GAS_DIVISOR())
+                default {
+                    evmGas := div(sub(_gas, requiredGas), GAS_DIVISOR())
+                }
             }
             
             function _getZkEVMGas(_evmGas) -> zkevmGas {

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -4226,6 +4226,1335 @@ object "EVMInterpreter" {
             }
             
 
+            function $llvm_NoInline_llvm$_simulate(
+                isCallerEVM,
+                evmGasLeft,
+                isStatic,
+            ) -> returnOffset, returnLen {
+
+                returnOffset := MEM_OFFSET_INNER()
+                returnLen := 0
+
+                // stack pointer - index to first stack element; empty stack = -1
+                let sp := sub(STACK_OFFSET(), 32)
+                // instruction pointer - index to next instruction. Not called pc because it's an
+                // actual yul/evm instruction.
+                let ip := add(BYTECODE_OFFSET(), 32)
+                let opcode
+                
+                let maxAcceptablePos := add(add(BYTECODE_OFFSET(), mload(BYTECODE_OFFSET())), 31)
+                
+                for { } true { } {
+                    opcode := readIP(ip,maxAcceptablePos)
+                
+                    ip := add(ip, 1)
+                
+                    switch opcode
+                    case 0x00 { // OP_STOP
+                        break
+                    }
+                    case 0x01 { // OP_ADD
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, add(a, b), evmGasLeft)
+                    }
+                    case 0x02 { // OP_MUL
+                        evmGasLeft := chargeGas(evmGasLeft, 5)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, mul(a, b), evmGasLeft)
+                    }
+                    case 0x03 { // OP_SUB
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, sub(a, b), evmGasLeft)
+                    }
+                    case 0x04 { // OP_DIV
+                        evmGasLeft := chargeGas(evmGasLeft, 5)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, div(a, b), evmGasLeft)
+                    }
+                    case 0x05 { // OP_SDIV
+                        evmGasLeft := chargeGas(evmGasLeft, 5)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, sdiv(a, b), evmGasLeft)
+                    }
+                    case 0x06 { // OP_MOD
+                        evmGasLeft := chargeGas(evmGasLeft, 5)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, mod(a, b), evmGasLeft)
+                    }
+                    case 0x07 { // OP_SMOD
+                        evmGasLeft := chargeGas(evmGasLeft, 5)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, smod(a, b), evmGasLeft)
+                    }
+                    case 0x08 { // OP_ADDMOD
+                        evmGasLeft := chargeGas(evmGasLeft, 8)
+                
+                        let a, b, N
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                        N, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, addmod(a, b, N), evmGasLeft)
+                    }
+                    case 0x09 { // OP_MULMOD
+                        evmGasLeft := chargeGas(evmGasLeft, 8)
+                
+                        let a, b, N
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                        N, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, mulmod(a, b, N), evmGasLeft)
+                    }
+                    case 0x0A { // OP_EXP
+                        evmGasLeft := chargeGas(evmGasLeft, 10)
+                
+                        let a, exponent
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        exponent, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, exp(a, exponent), evmGasLeft)
+                
+                        let to_charge := 0
+                        for {} gt(exponent,0) {} { // while exponent > 0
+                            to_charge := add(to_charge, 50)
+                            exponent := shr(8, exponent)
+                        } 
+                        evmGasLeft := chargeGas(evmGasLeft, to_charge)
+                    }
+                    case 0x0B { // OP_SIGNEXTEND
+                        evmGasLeft := chargeGas(evmGasLeft, 5)
+                
+                        let b, x
+                
+                        b, sp := popStackItem(sp, evmGasLeft)
+                        x, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, signextend(b, x), evmGasLeft)
+                    }
+                    case 0x10 { // OP_LT
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, lt(a, b), evmGasLeft)
+                    }
+                    case 0x11 { // OP_GT
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, gt(a, b), evmGasLeft)
+                    }
+                    case 0x12 { // OP_SLT
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, slt(a, b), evmGasLeft)
+                    }
+                    case 0x13 { // OP_SGT
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, sgt(a, b), evmGasLeft)
+                    }
+                    case 0x14 { // OP_EQ
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, eq(a, b), evmGasLeft)
+                    }
+                    case 0x15 { // OP_ISZERO
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let a
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, iszero(a), evmGasLeft)
+                    }
+                    case 0x16 { // OP_AND
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, and(a,b), evmGasLeft)
+                    }
+                    case 0x17 { // OP_OR
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, or(a,b), evmGasLeft)
+                    }
+                    case 0x18 { // OP_XOR
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let a, b
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, xor(a, b), evmGasLeft)
+                    }
+                    case 0x19 { // OP_NOT
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let a
+                
+                        a, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, not(a), evmGasLeft)
+                    }
+                    case 0x1A { // OP_BYTE
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let i, x
+                
+                        i, sp := popStackItem(sp, evmGasLeft)
+                        x, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, byte(i, x), evmGasLeft)
+                    }
+                    case 0x1B { // OP_SHL
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let shift, value
+                
+                        shift, sp := popStackItem(sp, evmGasLeft)
+                        value, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, shl(shift, value), evmGasLeft)
+                    }
+                    case 0x1C { // OP_SHR
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let shift, value
+                
+                        shift, sp := popStackItem(sp, evmGasLeft)
+                        value, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, shr(shift, value), evmGasLeft)
+                    }
+                    case 0x1D { // OP_SAR
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let shift, value
+                
+                        shift, sp := popStackItem(sp, evmGasLeft)
+                        value, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, sar(shift, value), evmGasLeft)
+                    }
+                    case 0x20 { // OP_KECCAK256
+                        evmGasLeft := chargeGas(evmGasLeft, 30)
+                
+                        let offset, size
+                
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        size, sp := popStackItem(sp, evmGasLeft)
+                
+                        checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
+                        checkMemOverflow(add(MEM_OFFSET_INNER(), add(offset, size)), evmGasLeft)
+                        let keccak := keccak256(add(MEM_OFFSET_INNER(), offset), size)
+                
+                        // When an offset is first accessed (either read or write), memory may trigger 
+                        // an expansion, which costs gas.
+                        // dynamicGas = 6 * minimum_word_size + memory_expansion_cost
+                        // minimum_word_size = (size + 31) / 32
+                        let dynamicGas := add(mul(6, shr(5, add(size, 31))), expandMemory(add(offset, size)))
+                        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
+                
+                        sp := pushStackItem(sp, keccak, evmGasLeft)
+                    }
+                    case 0x30 { // OP_ADDRESS
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                
+                        sp := pushStackItem(sp, address(), evmGasLeft)
+                    }
+                    case 0x31 { // OP_BALANCE
+                        evmGasLeft := chargeGas(evmGasLeft, 100)
+                
+                        let addr
+                
+                        addr, sp := popStackItem(sp, evmGasLeft)
+                        addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
+                
+                        if iszero(warmAddress(addr)) {
+                            evmGasLeft := chargeGas(evmGasLeft, 2500)
+                        }
+                
+                        sp := pushStackItem(sp, balance(addr), evmGasLeft)
+                    }
+                    case 0x32 { // OP_ORIGIN
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                
+                        sp := pushStackItem(sp, origin(), evmGasLeft)
+                    }
+                    case 0x33 { // OP_CALLER
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                
+                        sp := pushStackItem(sp, caller(), evmGasLeft)
+                    }
+                    case 0x34 { // OP_CALLVALUE
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                
+                        sp := pushStackItem(sp, callvalue(), evmGasLeft)
+                    }
+                    case 0x35 { // OP_CALLDATALOAD
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let i
+                
+                        i, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, calldataload(i), evmGasLeft)
+                    }
+                    case 0x36 { // OP_CALLDATASIZE
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                
+                        sp := pushStackItem(sp, calldatasize(), evmGasLeft)
+                    }
+                    case 0x37 { // OP_CALLDATACOPY
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let destOffset, offset, size
+                
+                        destOffset, sp := popStackItem(sp, evmGasLeft)
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        size, sp := popStackItem(sp, evmGasLeft)
+                
+                        checkMultipleOverflow(offset,size,MEM_OFFSET_INNER(), evmGasLeft)
+                        checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER(), evmGasLeft)
+                
+                        if or(gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM()), gt(add(add(destOffset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM())) {
+                            for { let i := 0 } lt(i, size) { i := add(i, 1) } {
+                                mstore8(
+                                    add(add(destOffset, MEM_OFFSET_INNER()), i),
+                                    0
+                                )
+                            }
+                        }
+                
+                        // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
+                        // minimum_word_size = (size + 31) / 32
+                        let dynamicGas := add(mul(3, shr(5, add(size, 31))), expandMemory(add(destOffset, size)))
+                        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
+                
+                        calldatacopy(add(destOffset, MEM_OFFSET_INNER()), offset, size)
+                        
+                    }
+                    case 0x38 { // OP_CODESIZE
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                
+                        let bytecodeLen := mload(BYTECODE_OFFSET())
+                        sp := pushStackItem(sp, bytecodeLen, evmGasLeft)
+                    }
+                    case 0x39 { // OP_CODECOPY
+                    
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let dst, offset, len
+                
+                        dst, sp := popStackItem(sp, evmGasLeft)
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        len, sp := popStackItem(sp, evmGasLeft)
+                
+                        // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
+                        // minimum_word_size = (size + 31) / 32
+                        let dynamicGas := add(mul(3, shr(5, add(len, 31))), expandMemory(add(dst, len)))
+                        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
+                
+                        dst := add(dst, MEM_OFFSET_INNER())
+                        offset := add(add(offset, BYTECODE_OFFSET()), 32)
+                
+                        checkOverflow(dst,len, evmGasLeft)
+                        checkMemOverflow(add(dst, len), evmGasLeft)
+                        // Check bytecode overflow
+                        if gt(add(offset, len), sub(MEM_OFFSET(), 1)) {
+                            revertWithGas(evmGasLeft)
+                        }
+                
+                        for { let i := 0 } lt(i, len) { i := add(i, 1) } {
+                            mstore8(
+                                add(dst, i),
+                                shr(248, mload(add(offset, i)))
+                            )
+                        }
+                        
+                    }
+                    case 0x3A { // OP_GASPRICE
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                
+                        sp := pushStackItem(sp, gasprice(), evmGasLeft)
+                    }
+                    case 0x3B { // OP_EXTCODESIZE
+                        evmGasLeft := chargeGas(evmGasLeft, 100)
+                
+                        let addr
+                        addr, sp := popStackItem(sp, evmGasLeft)
+                
+                        addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
+                        if iszero(warmAddress(addr)) {
+                            evmGasLeft := chargeGas(evmGasLeft, 2500)
+                        }
+                
+                        // TODO: check, the .sol uses extcodesize directly, but it doesnt seem to work
+                        // if a contract is created it works, but if the address is a zkSync's contract
+                        // what happens?
+                        // sp := pushStackItem(sp, extcodesize(addr), evmGasLeft)
+                
+                        switch _isEVM(addr) 
+                            case 0  { sp := pushStackItem(sp, extcodesize(addr), evmGasLeft) }
+                            default { sp := pushStackItem(sp, _fetchDeployedCodeLen(addr), evmGasLeft) }
+                    }
+                    case 0x3C { // OP_EXTCODECOPY
+                        evmGasLeft, sp := performExtCodeCopy(evmGasLeft, sp)
+                    }
+                    case 0x3D { // OP_RETURNDATASIZE
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                
+                        let rdz := mload(LAST_RETURNDATA_SIZE_OFFSET())
+                        sp := pushStackItem(sp, rdz, evmGasLeft)
+                    }
+                    case 0x3E { // OP_RETURNDATACOPY
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let dest, offset, len
+                        dest, sp := popStackItem(sp, evmGasLeft)
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        len, sp := popStackItem(sp, evmGasLeft)
+                
+                        // TODO: check if these conditions are met
+                        // The addition offset + size overflows.
+                        // offset + size is larger than RETURNDATASIZE.
+                        checkOverflow(offset,len, evmGasLeft)
+                        if gt(add(offset, len), mload(LAST_RETURNDATA_SIZE_OFFSET())) {
+                            revertWithGas(evmGasLeft)
+                        }
+                
+                        // minimum_word_size = (size + 31) / 32
+                        // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
+                        checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
+                        let dynamicGas := add(mul(3, shr(5, add(len, 31))), expandMemory(add(dest, len)))
+                        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
+                
+                        copyActivePtrData(add(MEM_OFFSET_INNER(), dest), offset, len)
+                    }
+                    case 0x3F { // OP_EXTCODEHASH
+                        evmGasLeft := chargeGas(evmGasLeft, 100)
+                
+                        let addr
+                        addr, sp := popStackItem(sp, evmGasLeft)
+                        addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
+                
+                        if iszero(warmAddress(addr)) {
+                            evmGasLeft := chargeGas(evmGasLeft, 2500) 
+                        }
+                
+                        if iszero(addr) {
+                            sp := pushStackItem(sp, 0, evmGasLeft)
+                            continue
+                        }
+                        sp := pushStackItem(sp, extcodehash(addr), evmGasLeft)
+                    }
+                    case 0x40 { // OP_BLOCKHASH
+                        evmGasLeft := chargeGas(evmGasLeft, 20)
+                
+                        let blockNumber
+                        blockNumber, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, blockhash(blockNumber), evmGasLeft)
+                    }
+                    case 0x41 { // OP_COINBASE
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                        sp := pushStackItem(sp, coinbase(), evmGasLeft)
+                    }
+                    case 0x42 { // OP_TIMESTAMP
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                        sp := pushStackItem(sp, timestamp(), evmGasLeft)
+                    }
+                    case 0x43 { // OP_NUMBER
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                        sp := pushStackItem(sp, number(), evmGasLeft)
+                    }
+                    case 0x44 { // OP_PREVRANDAO
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                        sp := pushStackItem(sp, prevrandao(), evmGasLeft)
+                    }
+                    case 0x45 { // OP_GASLIMIT
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                        sp := pushStackItem(sp, gaslimit(), evmGasLeft)
+                    }
+                    case 0x46 { // OP_CHAINID
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                        sp := pushStackItem(sp, chainid(), evmGasLeft)
+                    }
+                    case 0x47 { // OP_SELFBALANCE
+                        evmGasLeft := chargeGas(evmGasLeft, 5)
+                        sp := pushStackItem(sp, selfbalance(), evmGasLeft)
+                    }
+                    case 0x48 { // OP_BASEFEE
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                        sp := pushStackItem(sp, basefee(), evmGasLeft)
+                    }
+                    case 0x50 { // OP_POP
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                
+                        let _y
+                
+                        _y, sp := popStackItem(sp, evmGasLeft)
+                    }
+                    case 0x51 { // OP_MLOAD
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let offset
+                
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                
+                        checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
+                        let expansionGas := expandMemory(add(offset, 32))
+                        evmGasLeft := chargeGas(evmGasLeft, expansionGas)
+                
+                        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
+                        let memValue := mload(add(MEM_OFFSET_INNER(), offset))
+                        sp := pushStackItem(sp, memValue, evmGasLeft)
+                    }
+                    case 0x52 { // OP_MSTORE
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let offset, value
+                
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        value, sp := popStackItem(sp, evmGasLeft)
+                
+                        checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
+                        let expansionGas := expandMemory(add(offset, 32))
+                        evmGasLeft := chargeGas(evmGasLeft, expansionGas)
+                
+                        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
+                        mstore(add(MEM_OFFSET_INNER(), offset), value)
+                    }
+                    case 0x53 { // OP_MSTORE8
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let offset, value
+                
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        value, sp := popStackItem(sp, evmGasLeft)
+                
+                        checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
+                        let expansionGas := expandMemory(add(offset, 1))
+                        evmGasLeft := chargeGas(evmGasLeft, expansionGas)
+                
+                        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
+                        mstore8(add(MEM_OFFSET_INNER(), offset), value)
+                    }
+                    case 0x54 { // OP_SLOAD
+                    
+                        evmGasLeft := chargeGas(evmGasLeft, 100)
+                
+                        let key, value, isWarm
+                
+                        key, sp := popStackItem(sp, evmGasLeft)
+                
+                        let wasWarm := isSlotWarm(key)
+                
+                        if iszero(wasWarm) {
+                            evmGasLeft := chargeGas(evmGasLeft, 2000)
+                        }
+                
+                        value := sload(key)
+                
+                        if iszero(wasWarm) {
+                            let _wasW, _orgV := warmSlot(key, value)
+                        }
+                
+                        sp := pushStackItem(sp,value, evmGasLeft)
+                        
+                    }
+                    case 0x55 { // OP_SSTORE
+                        evmGasLeft := chargeGas(evmGasLeft, 100)
+                
+                        if isStatic {
+                            revertWithGas(evmGasLeft)
+                        }
+                
+                        let key, value, gasSpent
+                
+                        key, sp := popStackItem(sp, evmGasLeft)
+                        value, sp := popStackItem(sp, evmGasLeft)
+                
+                        {
+                            // Here it is okay to read before we charge since we known anyway that
+                            // the context has enough funds to compensate at least for the read.
+                            // Im not sure if we need this before: require(gasLeft > GAS_CALL_STIPEND);
+                            let currentValue := sload(key)
+                            let wasWarm, originalValue := warmSlot(key, currentValue)
+                
+                            if eq(value, currentValue) {
+                                continue
+                            }
+                
+                            if eq(originalValue, currentValue) {
+                                gasSpent := 19900
+                                if originalValue {
+                                    gasSpent := 2800
+                                }
+                            }
+                
+                            if iszero(wasWarm) {
+                                gasSpent := add(gasSpent, 2100)
+                            }
+                        }
+                
+                        evmGasLeft := chargeGas(evmGasLeft, gasSpent)
+                        sstore(key, value)
+                        
+                    }
+                    // NOTE: We don't currently do full jumpdest validation
+                    // (i.e. validating a jumpdest isn't in PUSH data)
+                    case 0x56 { // OP_JUMP
+                        evmGasLeft := chargeGas(evmGasLeft, 8)
+                
+                        let counter
+                
+                        counter, sp := popStackItem(sp, evmGasLeft)
+                
+                        ip := add(add(BYTECODE_OFFSET(), 32), counter)
+                
+                        // Check next opcode is JUMPDEST
+                        let nextOpcode := readIP(ip,maxAcceptablePos)
+                        if iszero(eq(nextOpcode, 0x5B)) {
+                            revertWithGas(evmGasLeft)
+                        }
+                    }
+                    case 0x57 { // OP_JUMPI
+                        evmGasLeft := chargeGas(evmGasLeft, 10)
+                
+                        let counter, b
+                
+                        counter, sp := popStackItem(sp, evmGasLeft)
+                        b, sp := popStackItem(sp, evmGasLeft)
+                
+                        if iszero(b) {
+                            continue
+                        }
+                
+                        ip := add(add(BYTECODE_OFFSET(), 32), counter)
+                
+                        // Check next opcode is JUMPDEST
+                        let nextOpcode := readIP(ip,maxAcceptablePos)
+                        if iszero(eq(nextOpcode, 0x5B)) {
+                            revertWithGas(evmGasLeft)
+                        }
+                    }
+                    case 0x58 { // OP_PC
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                
+                        // PC = ip - 32 (bytecode size) - 1 (current instruction)
+                        sp := pushStackItem(sp, sub(sub(ip, BYTECODE_OFFSET()), 33), evmGasLeft)
+                    }
+                    case 0x59 { // OP_MSIZE
+                        evmGasLeft := chargeGas(evmGasLeft,2)
+                
+                        let size
+                
+                        size := mload(MEM_OFFSET())
+                        size := shl(5,size)
+                        sp := pushStackItem(sp,size, evmGasLeft)
+                
+                    }
+                    case 0x5A { // OP_GAS
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                
+                        sp := pushStackItem(sp, evmGasLeft, evmGasLeft)
+                    }
+                    case 0x5B { // OP_JUMPDEST
+                        evmGasLeft := chargeGas(evmGasLeft, 1)
+                    }
+                    case 0x5C { // OP_TLOAD
+                        evmGasLeft := chargeGas(evmGasLeft, 100)
+                
+                        let key
+                        key, sp := popStackItem(sp, evmGasLeft)
+                
+                        sp := pushStackItem(sp, tload(key), evmGasLeft)
+                    }
+                    case 0x5D { // OP_TSTORE
+                        evmGasLeft := chargeGas(evmGasLeft, 100)
+                
+                        if isStatic {
+                            revertWithGas(evmGasLeft)
+                        }
+                
+                        let key, value
+                        key, sp := popStackItem(sp, evmGasLeft)
+                        value, sp := popStackItem(sp, evmGasLeft)
+                
+                        tstore(key, value)
+                    }
+                    case 0x5E { // OP_MCOPY
+                        let destOffset, offset, size
+                        destOffset, sp := popStackItem(sp, evmGasLeft)
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        size, sp := popStackItem(sp, evmGasLeft)
+                
+                        expandMemory(add(destOffset, size))
+                        expandMemory(add(offset, size))
+                
+                        let oldSize := mul(mload(MEM_OFFSET()),32)
+                        if gt(add(oldSize,size),MAX_POSSIBLE_MEM()) {
+                            revertWithGas(evmGasLeft)
+                        }
+                
+                        for { let i := 0 } lt(i, size) { i := add(i, 1) } {
+                            mstore8(
+                                add(add(oldSize,MEM_OFFSET_INNER()), i),
+                                shr(248,mload(add(add(offset,MEM_OFFSET_INNER()), i)))
+                            )
+                        }
+                        for { let i := 0 } lt(i, size) { i := add(i, 1) } {
+                            mstore8(
+                                add(add(destOffset,MEM_OFFSET_INNER()), i),
+                                shr(248,mload(add(add(oldSize,MEM_OFFSET_INNER()), i)))
+                            )
+                        }
+                    }
+                    case 0x5F { // OP_PUSH0
+                        evmGasLeft := chargeGas(evmGasLeft, 2)
+                
+                        let value := 0
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                    }
+                    case 0x60 { // OP_PUSH1
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,1)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 1)
+                    }
+                    case 0x61 { // OP_PUSH2
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,2)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 2)
+                    }     
+                    case 0x62 { // OP_PUSH3
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,3)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 3)
+                    }
+                    case 0x63 { // OP_PUSH4
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,4)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 4)
+                    }
+                    case 0x64 { // OP_PUSH5
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,5)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 5)
+                    }
+                    case 0x65 { // OP_PUSH6
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,6)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 6)
+                    }
+                    case 0x66 { // OP_PUSH7
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,7)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 7)
+                    }
+                    case 0x67 { // OP_PUSH8
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,8)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 8)
+                    }
+                    case 0x68 { // OP_PUSH9
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,9)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 9)
+                    }
+                    case 0x69 { // OP_PUSH10
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,10)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 10)
+                    }
+                    case 0x6A { // OP_PUSH11
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,11)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 11)
+                    }
+                    case 0x6B { // OP_PUSH12
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,12)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 12)
+                    }
+                    case 0x6C { // OP_PUSH13
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,13)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 13)
+                    }
+                    case 0x6D { // OP_PUSH14
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,14)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 14)
+                    }
+                    case 0x6E { // OP_PUSH15
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,15)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 15)
+                    }
+                    case 0x6F { // OP_PUSH16
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,16)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 16)
+                    }
+                    case 0x70 { // OP_PUSH17
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,17)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 17)
+                    }
+                    case 0x71 { // OP_PUSH18
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,18)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 18)
+                    }
+                    case 0x72 { // OP_PUSH19
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,19)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 19)
+                    }
+                    case 0x73 { // OP_PUSH20
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,20)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 20)
+                    }
+                    case 0x74 { // OP_PUSH21
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,21)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 21)
+                    }
+                    case 0x75 { // OP_PUSH22
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,22)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 22)
+                    }
+                    case 0x76 { // OP_PUSH23
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,23)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 23)
+                    }
+                    case 0x77 { // OP_PUSH24
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,24)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 24)
+                    }
+                    case 0x78 { // OP_PUSH25
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,25)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 25)
+                    }
+                    case 0x79 { // OP_PUSH26
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,26)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 26)
+                    }
+                    case 0x7A { // OP_PUSH27
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,27)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 27)
+                    }
+                    case 0x7B { // OP_PUSH28
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,28)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 28)
+                    }
+                    case 0x7C { // OP_PUSH29
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,29)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 29)
+                    }
+                    case 0x7D { // OP_PUSH30
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,30)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 30)
+                    }
+                    case 0x7E { // OP_PUSH31
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,31)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 31)
+                    }
+                    case 0x7F { // OP_PUSH32
+                        evmGasLeft := chargeGas(evmGasLeft, 3)
+                
+                        let value := readBytes(ip,maxAcceptablePos,32)
+                
+                        sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 32)
+                    }
+                    case 0x80 { // OP_DUP1 
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 1)
+                    }
+                    case 0x81 { // OP_DUP2
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 2)
+                    }
+                    case 0x82 { // OP_DUP3
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 3)
+                    }
+                    case 0x83 { // OP_DUP4    
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 4)
+                    }
+                    case 0x84 { // OP_DUP5
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 5)
+                    }
+                    case 0x85 { // OP_DUP6
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 6)
+                    }
+                    case 0x86 { // OP_DUP7    
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 7)
+                    }
+                    case 0x87 { // OP_DUP8
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 8)
+                    }
+                    case 0x88 { // OP_DUP9
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 9)
+                    }
+                    case 0x89 { // OP_DUP10   
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 10)
+                    }
+                    case 0x8A { // OP_DUP11
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 11)
+                    }
+                    case 0x8B { // OP_DUP12
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 12)
+                    }
+                    case 0x8C { // OP_DUP13
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 13)
+                    }
+                    case 0x8D { // OP_DUP14
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 14)
+                    }
+                    case 0x8E { // OP_DUP15
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 15)
+                    }
+                    case 0x8F { // OP_DUP16
+                        sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 16)
+                    }
+                    case 0x90 { // OP_SWAP1 
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 1)
+                    }
+                    case 0x91 { // OP_SWAP2
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 2)
+                    }
+                    case 0x92 { // OP_SWAP3
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 3)
+                    }
+                    case 0x93 { // OP_SWAP4    
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 4)
+                    }
+                    case 0x94 { // OP_SWAP5
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 5)
+                    }
+                    case 0x95 { // OP_SWAP6
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 6)
+                    }
+                    case 0x96 { // OP_SWAP7    
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 7)
+                    }
+                    case 0x97 { // OP_SWAP8
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 8)
+                    }
+                    case 0x98 { // OP_SWAP9
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 9)
+                    }
+                    case 0x99 { // OP_SWAP10   
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 10)
+                    }
+                    case 0x9A { // OP_SWAP11
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 11)
+                    }
+                    case 0x9B { // OP_SWAP12
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 12)
+                    }
+                    case 0x9C { // OP_SWAP13
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 13)
+                    }
+                    case 0x9D { // OP_SWAP14
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 14)
+                    }
+                    case 0x9E { // OP_SWAP15
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 15)
+                    }
+                    case 0x9F { // OP_SWAP16
+                        evmGasLeft := swapStackItem(sp, evmGasLeft, 16)
+                    }
+                    case 0xA0 { // OP_LOG0
+                        evmGasLeft := chargeGas(evmGasLeft, 375)
+                
+                        if isStatic {
+                            revertWithGas(evmGasLeft)
+                        }
+                
+                        let offset, size
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        size, sp := popStackItem(sp, evmGasLeft)
+                
+                        checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
+                        checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
+                
+                        // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
+                        let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
+                        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
+                
+                        log0(add(offset, MEM_OFFSET_INNER()), size)
+                    }
+                    case 0xA1 { // OP_LOG1
+                        evmGasLeft := chargeGas(evmGasLeft, 375)
+                
+                        if isStatic {
+                            revertWithGas(evmGasLeft)
+                        }
+                
+                        let offset, size, topic1
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        size, sp := popStackItem(sp, evmGasLeft)
+                        topic1, sp := popStackItem(sp, evmGasLeft)
+                
+                        checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
+                        checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
+                
+                        // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
+                        let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
+                        dynamicGas := add(dynamicGas, 375)
+                        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
+                
+                        log1(add(offset, MEM_OFFSET_INNER()), size, topic1)
+                    }
+                    case 0xA2 { // OP_LOG2
+                        evmGasLeft := chargeGas(evmGasLeft, 375)
+                        if isStatic {
+                            revertWithGas(evmGasLeft)
+                        }
+                
+                        let offset, size
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        size, sp := popStackItem(sp, evmGasLeft)
+                
+                        checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
+                        checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
+                
+                        // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
+                        let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
+                        dynamicGas := add(dynamicGas, 750)
+                        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
+                
+                        {
+                            let topic1, topic2
+                            topic1, sp := popStackItem(sp, evmGasLeft)
+                            topic2, sp := popStackItem(sp, evmGasLeft)
+                            log2(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2)
+                        }
+                    }
+                    case 0xA3 { // OP_LOG3
+                        evmGasLeft := chargeGas(evmGasLeft, 375)
+                
+                        if isStatic {
+                            revertWithGas(evmGasLeft)
+                        }
+                
+                        let offset, size
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        size, sp := popStackItem(sp, evmGasLeft)
+                
+                        checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
+                
+                        checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
+                
+                        // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
+                        let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
+                        dynamicGas := add(dynamicGas, 1125)
+                        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
+                
+                        {
+                            let topic1, topic2, topic3
+                            topic1, sp := popStackItem(sp, evmGasLeft)
+                            topic2, sp := popStackItem(sp, evmGasLeft)
+                            topic3, sp := popStackItem(sp, evmGasLeft)
+                            log3(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3)
+                        }     
+                    }
+                    case 0xA4 { // OP_LOG4
+                        evmGasLeft := chargeGas(evmGasLeft, 375)
+                
+                        if isStatic {
+                            revertWithGas(evmGasLeft)
+                        }
+                
+                        let offset, size
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        size, sp := popStackItem(sp, evmGasLeft)
+                
+                        checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
+                        checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
+                
+                        // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
+                        let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
+                        dynamicGas := add(dynamicGas, 1500)
+                        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
+                
+                        {
+                            let topic1, topic2, topic3, topic4
+                            topic1, sp := popStackItem(sp, evmGasLeft)
+                            topic2, sp := popStackItem(sp, evmGasLeft)
+                            topic3, sp := popStackItem(sp, evmGasLeft)
+                            topic4, sp := popStackItem(sp, evmGasLeft)
+                            log4(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3, topic4)
+                        }     
+                    }
+                    case 0xF0 { // OP_CREATE
+                        evmGasLeft, sp := performCreate(evmGasLeft, sp, isStatic)
+                    }
+                    case 0xF1 { // OP_CALL
+                        evmGasLeft := chargeGas(evmGasLeft, 100)
+                
+                        let gasUsed
+                
+                        // A function was implemented in order to avoid stack depth errors.
+                        gasUsed, sp := performCall(sp, evmGasLeft, isStatic)
+                
+                        // Check if the following is ok
+                        evmGasLeft := chargeGas(evmGasLeft, gasUsed)
+                    }
+                    case 0xF3 { // OP_RETURN
+                        let offset,size
+                
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        size, sp := popStackItem(sp, evmGasLeft)
+                
+                        checkOverflow(offset,size, evmGasLeft)
+                        evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
+                
+                        returnLen := size
+                        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
+                        returnOffset := add(MEM_OFFSET_INNER(), offset)
+                        break
+                    }
+                    case 0xF4 { // OP_DELEGATECALL
+                        evmGasLeft := chargeGas(evmGasLeft, 100)
+                
+                        let gasUsed
+                        sp, isStatic, gasUsed := delegateCall(sp, isStatic, evmGasLeft)
+                
+                        evmGasLeft := chargeGas(evmGasLeft, gasUsed)
+                    }
+                    case 0xF5 { // OP_CREATE2
+                        let result, addr
+                        evmGasLeft, sp, result, addr := performCreate2(evmGasLeft, sp, isStatic)
+                        switch result
+                        case 0 { sp := pushStackItem(sp, 0, evmGasLeft) }
+                        default { sp := pushStackItem(sp, addr, evmGasLeft) }
+                    }
+                    case 0xFA { // OP_STATICCALL
+                        evmGasLeft := chargeGas(evmGasLeft, 100)
+                
+                        let gasUsed
+                        gasUsed, sp := performStaticCall(sp,evmGasLeft)
+                        evmGasLeft := chargeGas(evmGasLeft,gasUsed)
+                    }
+                    case 0xFD { // OP_REVERT
+                        let offset,size
+                
+                        offset, sp := popStackItem(sp, evmGasLeft)
+                        size, sp := popStackItem(sp, evmGasLeft)
+                
+                        ensureAcceptableMemLocation(offset)
+                        ensureAcceptableMemLocation(size)
+                        evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
+                
+                        offset := add(offset, MEM_OFFSET_INNER())
+                        offset,size := addGasIfEvmRevert(isCallerEVM,offset,size,evmGasLeft)
+                
+                        revert(offset,size)
+                    }
+                    case 0xFE { // OP_INVALID
+                        evmGasLeft := 0
+                
+                        revertWithGas(evmGasLeft)
+                    }
+                    default {
+                        printString("INVALID OPCODE")
+                        printHex(opcode)
+                        revert(0, 0)
+                    }
+                }
+                
+
+                if eq(isCallerEVM, 1) {
+                    // Includes gas
+                    returnOffset := sub(returnOffset, 32)
+                    checkOverflow(returnLen, 32, evmGasLeft)
+                    returnLen := add(returnLen, 32)
+
+                    mstore(returnOffset, evmGasLeft)
+                }
+            }
+
             ////////////////////////////////////////////////////////////////
             //                      FALLBACK
             ////////////////////////////////////////////////////////////////
@@ -4241,1330 +5570,9 @@ object "EVMInterpreter" {
             // segment of memory.
             getDeployedBytecode()
 
-            let returnOffset := MEM_OFFSET_INNER()
-            let returnLen := 0
-
             pop(warmAddress(address()))
 
-            // stack pointer - index to first stack element; empty stack = -1
-            let sp := sub(STACK_OFFSET(), 32)
-            // instruction pointer - index to next instruction. Not called pc because it's an
-            // actual yul/evm instruction.
-            let ip := add(BYTECODE_OFFSET(), 32)
-            let opcode
-            
-            let maxAcceptablePos := add(add(BYTECODE_OFFSET(), mload(BYTECODE_OFFSET())), 31)
-            
-            for { } true { } {
-                opcode := readIP(ip,maxAcceptablePos)
-            
-                ip := add(ip, 1)
-            
-                switch opcode
-                case 0x00 { // OP_STOP
-                    break
-                }
-                case 0x01 { // OP_ADD
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, add(a, b), evmGasLeft)
-                }
-                case 0x02 { // OP_MUL
-                    evmGasLeft := chargeGas(evmGasLeft, 5)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, mul(a, b), evmGasLeft)
-                }
-                case 0x03 { // OP_SUB
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, sub(a, b), evmGasLeft)
-                }
-                case 0x04 { // OP_DIV
-                    evmGasLeft := chargeGas(evmGasLeft, 5)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, div(a, b), evmGasLeft)
-                }
-                case 0x05 { // OP_SDIV
-                    evmGasLeft := chargeGas(evmGasLeft, 5)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, sdiv(a, b), evmGasLeft)
-                }
-                case 0x06 { // OP_MOD
-                    evmGasLeft := chargeGas(evmGasLeft, 5)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, mod(a, b), evmGasLeft)
-                }
-                case 0x07 { // OP_SMOD
-                    evmGasLeft := chargeGas(evmGasLeft, 5)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, smod(a, b), evmGasLeft)
-                }
-                case 0x08 { // OP_ADDMOD
-                    evmGasLeft := chargeGas(evmGasLeft, 8)
-            
-                    let a, b, N
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-                    N, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, addmod(a, b, N), evmGasLeft)
-                }
-                case 0x09 { // OP_MULMOD
-                    evmGasLeft := chargeGas(evmGasLeft, 8)
-            
-                    let a, b, N
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-                    N, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, mulmod(a, b, N), evmGasLeft)
-                }
-                case 0x0A { // OP_EXP
-                    evmGasLeft := chargeGas(evmGasLeft, 10)
-            
-                    let a, exponent
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    exponent, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, exp(a, exponent), evmGasLeft)
-            
-                    let to_charge := 0
-                    for {} gt(exponent,0) {} { // while exponent > 0
-                        to_charge := add(to_charge, 50)
-                        exponent := shr(8, exponent)
-                    } 
-                    evmGasLeft := chargeGas(evmGasLeft, to_charge)
-                }
-                case 0x0B { // OP_SIGNEXTEND
-                    evmGasLeft := chargeGas(evmGasLeft, 5)
-            
-                    let b, x
-            
-                    b, sp := popStackItem(sp, evmGasLeft)
-                    x, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, signextend(b, x), evmGasLeft)
-                }
-                case 0x10 { // OP_LT
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, lt(a, b), evmGasLeft)
-                }
-                case 0x11 { // OP_GT
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, gt(a, b), evmGasLeft)
-                }
-                case 0x12 { // OP_SLT
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, slt(a, b), evmGasLeft)
-                }
-                case 0x13 { // OP_SGT
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, sgt(a, b), evmGasLeft)
-                }
-                case 0x14 { // OP_EQ
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, eq(a, b), evmGasLeft)
-                }
-                case 0x15 { // OP_ISZERO
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let a
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, iszero(a), evmGasLeft)
-                }
-                case 0x16 { // OP_AND
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, and(a,b), evmGasLeft)
-                }
-                case 0x17 { // OP_OR
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, or(a,b), evmGasLeft)
-                }
-                case 0x18 { // OP_XOR
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let a, b
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, xor(a, b), evmGasLeft)
-                }
-                case 0x19 { // OP_NOT
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let a
-            
-                    a, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, not(a), evmGasLeft)
-                }
-                case 0x1A { // OP_BYTE
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let i, x
-            
-                    i, sp := popStackItem(sp, evmGasLeft)
-                    x, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, byte(i, x), evmGasLeft)
-                }
-                case 0x1B { // OP_SHL
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let shift, value
-            
-                    shift, sp := popStackItem(sp, evmGasLeft)
-                    value, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, shl(shift, value), evmGasLeft)
-                }
-                case 0x1C { // OP_SHR
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let shift, value
-            
-                    shift, sp := popStackItem(sp, evmGasLeft)
-                    value, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, shr(shift, value), evmGasLeft)
-                }
-                case 0x1D { // OP_SAR
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let shift, value
-            
-                    shift, sp := popStackItem(sp, evmGasLeft)
-                    value, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, sar(shift, value), evmGasLeft)
-                }
-                case 0x20 { // OP_KECCAK256
-                    evmGasLeft := chargeGas(evmGasLeft, 30)
-            
-                    let offset, size
-            
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    size, sp := popStackItem(sp, evmGasLeft)
-            
-                    checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
-                    checkMemOverflow(add(MEM_OFFSET_INNER(), add(offset, size)), evmGasLeft)
-                    let keccak := keccak256(add(MEM_OFFSET_INNER(), offset), size)
-            
-                    // When an offset is first accessed (either read or write), memory may trigger 
-                    // an expansion, which costs gas.
-                    // dynamicGas = 6 * minimum_word_size + memory_expansion_cost
-                    // minimum_word_size = (size + 31) / 32
-                    let dynamicGas := add(mul(6, shr(5, add(size, 31))), expandMemory(add(offset, size)))
-                    evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
-            
-                    sp := pushStackItem(sp, keccak, evmGasLeft)
-                }
-                case 0x30 { // OP_ADDRESS
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-            
-                    sp := pushStackItem(sp, address(), evmGasLeft)
-                }
-                case 0x31 { // OP_BALANCE
-                    evmGasLeft := chargeGas(evmGasLeft, 100)
-            
-                    let addr
-            
-                    addr, sp := popStackItem(sp, evmGasLeft)
-                    addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
-            
-                    if iszero(warmAddress(addr)) {
-                        evmGasLeft := chargeGas(evmGasLeft, 2500)
-                    }
-            
-                    sp := pushStackItem(sp, balance(addr), evmGasLeft)
-                }
-                case 0x32 { // OP_ORIGIN
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-            
-                    sp := pushStackItem(sp, origin(), evmGasLeft)
-                }
-                case 0x33 { // OP_CALLER
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-            
-                    sp := pushStackItem(sp, caller(), evmGasLeft)
-                }
-                case 0x34 { // OP_CALLVALUE
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-            
-                    sp := pushStackItem(sp, callvalue(), evmGasLeft)
-                }
-                case 0x35 { // OP_CALLDATALOAD
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let i
-            
-                    i, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, calldataload(i), evmGasLeft)
-                }
-                case 0x36 { // OP_CALLDATASIZE
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-            
-                    sp := pushStackItem(sp, calldatasize(), evmGasLeft)
-                }
-                case 0x37 { // OP_CALLDATACOPY
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let destOffset, offset, size
-            
-                    destOffset, sp := popStackItem(sp, evmGasLeft)
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    size, sp := popStackItem(sp, evmGasLeft)
-            
-                    checkMultipleOverflow(offset,size,MEM_OFFSET_INNER(), evmGasLeft)
-                    checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER(), evmGasLeft)
-            
-                    if or(gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM()), gt(add(add(destOffset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM())) {
-                        for { let i := 0 } lt(i, size) { i := add(i, 1) } {
-                            mstore8(
-                                add(add(destOffset, MEM_OFFSET_INNER()), i),
-                                0
-                            )
-                        }
-                    }
-            
-                    // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
-                    // minimum_word_size = (size + 31) / 32
-                    let dynamicGas := add(mul(3, shr(5, add(size, 31))), expandMemory(add(destOffset, size)))
-                    evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
-            
-                    calldatacopy(add(destOffset, MEM_OFFSET_INNER()), offset, size)
-                    
-                }
-                case 0x38 { // OP_CODESIZE
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-            
-                    let bytecodeLen := mload(BYTECODE_OFFSET())
-                    sp := pushStackItem(sp, bytecodeLen, evmGasLeft)
-                }
-                case 0x39 { // OP_CODECOPY
-                
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let dst, offset, len
-            
-                    dst, sp := popStackItem(sp, evmGasLeft)
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    len, sp := popStackItem(sp, evmGasLeft)
-            
-                    // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
-                    // minimum_word_size = (size + 31) / 32
-                    let dynamicGas := add(mul(3, shr(5, add(len, 31))), expandMemory(add(dst, len)))
-                    evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
-            
-                    dst := add(dst, MEM_OFFSET_INNER())
-                    offset := add(add(offset, BYTECODE_OFFSET()), 32)
-            
-                    checkOverflow(dst,len, evmGasLeft)
-                    checkMemOverflow(add(dst, len), evmGasLeft)
-                    // Check bytecode overflow
-                    if gt(add(offset, len), sub(MEM_OFFSET(), 1)) {
-                        revertWithGas(evmGasLeft)
-                    }
-            
-                    for { let i := 0 } lt(i, len) { i := add(i, 1) } {
-                        mstore8(
-                            add(dst, i),
-                            shr(248, mload(add(offset, i)))
-                        )
-                    }
-                    
-                }
-                case 0x3A { // OP_GASPRICE
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-            
-                    sp := pushStackItem(sp, gasprice(), evmGasLeft)
-                }
-                case 0x3B { // OP_EXTCODESIZE
-                    evmGasLeft := chargeGas(evmGasLeft, 100)
-            
-                    let addr
-                    addr, sp := popStackItem(sp, evmGasLeft)
-            
-                    addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
-                    if iszero(warmAddress(addr)) {
-                        evmGasLeft := chargeGas(evmGasLeft, 2500)
-                    }
-            
-                    // TODO: check, the .sol uses extcodesize directly, but it doesnt seem to work
-                    // if a contract is created it works, but if the address is a zkSync's contract
-                    // what happens?
-                    // sp := pushStackItem(sp, extcodesize(addr), evmGasLeft)
-            
-                    switch _isEVM(addr) 
-                        case 0  { sp := pushStackItem(sp, extcodesize(addr), evmGasLeft) }
-                        default { sp := pushStackItem(sp, _fetchDeployedCodeLen(addr), evmGasLeft) }
-                }
-                case 0x3C { // OP_EXTCODECOPY
-                    evmGasLeft, sp := performExtCodeCopy(evmGasLeft, sp)
-                }
-                case 0x3D { // OP_RETURNDATASIZE
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-            
-                    let rdz := mload(LAST_RETURNDATA_SIZE_OFFSET())
-                    sp := pushStackItem(sp, rdz, evmGasLeft)
-                }
-                case 0x3E { // OP_RETURNDATACOPY
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let dest, offset, len
-                    dest, sp := popStackItem(sp, evmGasLeft)
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    len, sp := popStackItem(sp, evmGasLeft)
-            
-                    // TODO: check if these conditions are met
-                    // The addition offset + size overflows.
-                    // offset + size is larger than RETURNDATASIZE.
-                    checkOverflow(offset,len, evmGasLeft)
-                    if gt(add(offset, len), mload(LAST_RETURNDATA_SIZE_OFFSET())) {
-                        revertWithGas(evmGasLeft)
-                    }
-            
-                    // minimum_word_size = (size + 31) / 32
-                    // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
-                    checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
-                    let dynamicGas := add(mul(3, shr(5, add(len, 31))), expandMemory(add(dest, len)))
-                    evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
-            
-                    copyActivePtrData(add(MEM_OFFSET_INNER(), dest), offset, len)
-                }
-                case 0x3F { // OP_EXTCODEHASH
-                    evmGasLeft := chargeGas(evmGasLeft, 100)
-            
-                    let addr
-                    addr, sp := popStackItem(sp, evmGasLeft)
-                    addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
-            
-                    if iszero(warmAddress(addr)) {
-                        evmGasLeft := chargeGas(evmGasLeft, 2500) 
-                    }
-            
-                    if iszero(addr) {
-                        sp := pushStackItem(sp, 0, evmGasLeft)
-                        continue
-                    }
-                    sp := pushStackItem(sp, extcodehash(addr), evmGasLeft)
-                }
-                case 0x40 { // OP_BLOCKHASH
-                    evmGasLeft := chargeGas(evmGasLeft, 20)
-            
-                    let blockNumber
-                    blockNumber, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, blockhash(blockNumber), evmGasLeft)
-                }
-                case 0x41 { // OP_COINBASE
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-                    sp := pushStackItem(sp, coinbase(), evmGasLeft)
-                }
-                case 0x42 { // OP_TIMESTAMP
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-                    sp := pushStackItem(sp, timestamp(), evmGasLeft)
-                }
-                case 0x43 { // OP_NUMBER
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-                    sp := pushStackItem(sp, number(), evmGasLeft)
-                }
-                case 0x44 { // OP_PREVRANDAO
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-                    sp := pushStackItem(sp, prevrandao(), evmGasLeft)
-                }
-                case 0x45 { // OP_GASLIMIT
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-                    sp := pushStackItem(sp, gaslimit(), evmGasLeft)
-                }
-                case 0x46 { // OP_CHAINID
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-                    sp := pushStackItem(sp, chainid(), evmGasLeft)
-                }
-                case 0x47 { // OP_SELFBALANCE
-                    evmGasLeft := chargeGas(evmGasLeft, 5)
-                    sp := pushStackItem(sp, selfbalance(), evmGasLeft)
-                }
-                case 0x48 { // OP_BASEFEE
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-                    sp := pushStackItem(sp, basefee(), evmGasLeft)
-                }
-                case 0x50 { // OP_POP
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-            
-                    let _y
-            
-                    _y, sp := popStackItem(sp, evmGasLeft)
-                }
-                case 0x51 { // OP_MLOAD
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let offset
-            
-                    offset, sp := popStackItem(sp, evmGasLeft)
-            
-                    checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
-                    let expansionGas := expandMemory(add(offset, 32))
-                    evmGasLeft := chargeGas(evmGasLeft, expansionGas)
-            
-                    checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
-                    let memValue := mload(add(MEM_OFFSET_INNER(), offset))
-                    sp := pushStackItem(sp, memValue, evmGasLeft)
-                }
-                case 0x52 { // OP_MSTORE
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let offset, value
-            
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    value, sp := popStackItem(sp, evmGasLeft)
-            
-                    checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
-                    let expansionGas := expandMemory(add(offset, 32))
-                    evmGasLeft := chargeGas(evmGasLeft, expansionGas)
-            
-                    checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
-                    mstore(add(MEM_OFFSET_INNER(), offset), value)
-                }
-                case 0x53 { // OP_MSTORE8
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let offset, value
-            
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    value, sp := popStackItem(sp, evmGasLeft)
-            
-                    checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
-                    let expansionGas := expandMemory(add(offset, 1))
-                    evmGasLeft := chargeGas(evmGasLeft, expansionGas)
-            
-                    checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
-                    mstore8(add(MEM_OFFSET_INNER(), offset), value)
-                }
-                case 0x54 { // OP_SLOAD
-                
-                    evmGasLeft := chargeGas(evmGasLeft, 100)
-            
-                    let key, value, isWarm
-            
-                    key, sp := popStackItem(sp, evmGasLeft)
-            
-                    let wasWarm := isSlotWarm(key)
-            
-                    if iszero(wasWarm) {
-                        evmGasLeft := chargeGas(evmGasLeft, 2000)
-                    }
-            
-                    value := sload(key)
-            
-                    if iszero(wasWarm) {
-                        let _wasW, _orgV := warmSlot(key, value)
-                    }
-            
-                    sp := pushStackItem(sp,value, evmGasLeft)
-                    
-                }
-                case 0x55 { // OP_SSTORE
-                    evmGasLeft := chargeGas(evmGasLeft, 100)
-            
-                    if isStatic {
-                        revertWithGas(evmGasLeft)
-                    }
-            
-                    let key, value, gasSpent
-            
-                    key, sp := popStackItem(sp, evmGasLeft)
-                    value, sp := popStackItem(sp, evmGasLeft)
-            
-                    {
-                        // Here it is okay to read before we charge since we known anyway that
-                        // the context has enough funds to compensate at least for the read.
-                        // Im not sure if we need this before: require(gasLeft > GAS_CALL_STIPEND);
-                        let currentValue := sload(key)
-                        let wasWarm, originalValue := warmSlot(key, currentValue)
-            
-                        if eq(value, currentValue) {
-                            continue
-                        }
-            
-                        if eq(originalValue, currentValue) {
-                            gasSpent := 19900
-                            if originalValue {
-                                gasSpent := 2800
-                            }
-                        }
-            
-                        if iszero(wasWarm) {
-                            gasSpent := add(gasSpent, 2100)
-                        }
-                    }
-            
-                    evmGasLeft := chargeGas(evmGasLeft, gasSpent)
-                    sstore(key, value)
-                    
-                }
-                // NOTE: We don't currently do full jumpdest validation
-                // (i.e. validating a jumpdest isn't in PUSH data)
-                case 0x56 { // OP_JUMP
-                    evmGasLeft := chargeGas(evmGasLeft, 8)
-            
-                    let counter
-            
-                    counter, sp := popStackItem(sp, evmGasLeft)
-            
-                    ip := add(add(BYTECODE_OFFSET(), 32), counter)
-            
-                    // Check next opcode is JUMPDEST
-                    let nextOpcode := readIP(ip,maxAcceptablePos)
-                    if iszero(eq(nextOpcode, 0x5B)) {
-                        revertWithGas(evmGasLeft)
-                    }
-                }
-                case 0x57 { // OP_JUMPI
-                    evmGasLeft := chargeGas(evmGasLeft, 10)
-            
-                    let counter, b
-            
-                    counter, sp := popStackItem(sp, evmGasLeft)
-                    b, sp := popStackItem(sp, evmGasLeft)
-            
-                    if iszero(b) {
-                        continue
-                    }
-            
-                    ip := add(add(BYTECODE_OFFSET(), 32), counter)
-            
-                    // Check next opcode is JUMPDEST
-                    let nextOpcode := readIP(ip,maxAcceptablePos)
-                    if iszero(eq(nextOpcode, 0x5B)) {
-                        revertWithGas(evmGasLeft)
-                    }
-                }
-                case 0x58 { // OP_PC
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-            
-                    // PC = ip - 32 (bytecode size) - 1 (current instruction)
-                    sp := pushStackItem(sp, sub(sub(ip, BYTECODE_OFFSET()), 33), evmGasLeft)
-                }
-                case 0x59 { // OP_MSIZE
-                    evmGasLeft := chargeGas(evmGasLeft,2)
-            
-                    let size
-            
-                    size := mload(MEM_OFFSET())
-                    size := shl(5,size)
-                    sp := pushStackItem(sp,size, evmGasLeft)
-            
-                }
-                case 0x5A { // OP_GAS
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-            
-                    sp := pushStackItem(sp, evmGasLeft, evmGasLeft)
-                }
-                case 0x5B { // OP_JUMPDEST
-                    evmGasLeft := chargeGas(evmGasLeft, 1)
-                }
-                case 0x5C { // OP_TLOAD
-                    evmGasLeft := chargeGas(evmGasLeft, 100)
-            
-                    let key
-                    key, sp := popStackItem(sp, evmGasLeft)
-            
-                    sp := pushStackItem(sp, tload(key), evmGasLeft)
-                }
-                case 0x5D { // OP_TSTORE
-                    evmGasLeft := chargeGas(evmGasLeft, 100)
-            
-                    if isStatic {
-                        revertWithGas(evmGasLeft)
-                    }
-            
-                    let key, value
-                    key, sp := popStackItem(sp, evmGasLeft)
-                    value, sp := popStackItem(sp, evmGasLeft)
-            
-                    tstore(key, value)
-                }
-                case 0x5E { // OP_MCOPY
-                    let destOffset, offset, size
-                    destOffset, sp := popStackItem(sp, evmGasLeft)
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    size, sp := popStackItem(sp, evmGasLeft)
-            
-                    expandMemory(add(destOffset, size))
-                    expandMemory(add(offset, size))
-            
-                    let oldSize := mul(mload(MEM_OFFSET()),32)
-                    if gt(add(oldSize,size),MAX_POSSIBLE_MEM()) {
-                        revertWithGas(evmGasLeft)
-                    }
-            
-                    for { let i := 0 } lt(i, size) { i := add(i, 1) } {
-                        mstore8(
-                            add(add(oldSize,MEM_OFFSET_INNER()), i),
-                            shr(248,mload(add(add(offset,MEM_OFFSET_INNER()), i)))
-                        )
-                    }
-                    for { let i := 0 } lt(i, size) { i := add(i, 1) } {
-                        mstore8(
-                            add(add(destOffset,MEM_OFFSET_INNER()), i),
-                            shr(248,mload(add(add(oldSize,MEM_OFFSET_INNER()), i)))
-                        )
-                    }
-                }
-                case 0x5F { // OP_PUSH0
-                    evmGasLeft := chargeGas(evmGasLeft, 2)
-            
-                    let value := 0
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                }
-                case 0x60 { // OP_PUSH1
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,1)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 1)
-                }
-                case 0x61 { // OP_PUSH2
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,2)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 2)
-                }     
-                case 0x62 { // OP_PUSH3
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,3)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 3)
-                }
-                case 0x63 { // OP_PUSH4
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,4)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 4)
-                }
-                case 0x64 { // OP_PUSH5
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,5)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 5)
-                }
-                case 0x65 { // OP_PUSH6
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,6)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 6)
-                }
-                case 0x66 { // OP_PUSH7
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,7)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 7)
-                }
-                case 0x67 { // OP_PUSH8
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,8)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 8)
-                }
-                case 0x68 { // OP_PUSH9
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,9)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 9)
-                }
-                case 0x69 { // OP_PUSH10
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,10)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 10)
-                }
-                case 0x6A { // OP_PUSH11
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,11)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 11)
-                }
-                case 0x6B { // OP_PUSH12
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,12)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 12)
-                }
-                case 0x6C { // OP_PUSH13
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,13)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 13)
-                }
-                case 0x6D { // OP_PUSH14
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,14)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 14)
-                }
-                case 0x6E { // OP_PUSH15
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,15)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 15)
-                }
-                case 0x6F { // OP_PUSH16
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,16)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 16)
-                }
-                case 0x70 { // OP_PUSH17
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,17)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 17)
-                }
-                case 0x71 { // OP_PUSH18
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,18)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 18)
-                }
-                case 0x72 { // OP_PUSH19
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,19)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 19)
-                }
-                case 0x73 { // OP_PUSH20
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,20)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 20)
-                }
-                case 0x74 { // OP_PUSH21
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,21)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 21)
-                }
-                case 0x75 { // OP_PUSH22
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,22)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 22)
-                }
-                case 0x76 { // OP_PUSH23
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,23)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 23)
-                }
-                case 0x77 { // OP_PUSH24
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,24)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 24)
-                }
-                case 0x78 { // OP_PUSH25
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,25)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 25)
-                }
-                case 0x79 { // OP_PUSH26
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,26)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 26)
-                }
-                case 0x7A { // OP_PUSH27
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,27)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 27)
-                }
-                case 0x7B { // OP_PUSH28
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,28)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 28)
-                }
-                case 0x7C { // OP_PUSH29
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,29)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 29)
-                }
-                case 0x7D { // OP_PUSH30
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,30)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 30)
-                }
-                case 0x7E { // OP_PUSH31
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,31)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 31)
-                }
-                case 0x7F { // OP_PUSH32
-                    evmGasLeft := chargeGas(evmGasLeft, 3)
-            
-                    let value := readBytes(ip,maxAcceptablePos,32)
-            
-                    sp := pushStackItem(sp, value, evmGasLeft)
-                    ip := add(ip, 32)
-                }
-                case 0x80 { // OP_DUP1 
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 1)
-                }
-                case 0x81 { // OP_DUP2
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 2)
-                }
-                case 0x82 { // OP_DUP3
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 3)
-                }
-                case 0x83 { // OP_DUP4    
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 4)
-                }
-                case 0x84 { // OP_DUP5
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 5)
-                }
-                case 0x85 { // OP_DUP6
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 6)
-                }
-                case 0x86 { // OP_DUP7    
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 7)
-                }
-                case 0x87 { // OP_DUP8
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 8)
-                }
-                case 0x88 { // OP_DUP9
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 9)
-                }
-                case 0x89 { // OP_DUP10   
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 10)
-                }
-                case 0x8A { // OP_DUP11
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 11)
-                }
-                case 0x8B { // OP_DUP12
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 12)
-                }
-                case 0x8C { // OP_DUP13
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 13)
-                }
-                case 0x8D { // OP_DUP14
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 14)
-                }
-                case 0x8E { // OP_DUP15
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 15)
-                }
-                case 0x8F { // OP_DUP16
-                    sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 16)
-                }
-                case 0x90 { // OP_SWAP1 
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 1)
-                }
-                case 0x91 { // OP_SWAP2
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 2)
-                }
-                case 0x92 { // OP_SWAP3
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 3)
-                }
-                case 0x93 { // OP_SWAP4    
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 4)
-                }
-                case 0x94 { // OP_SWAP5
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 5)
-                }
-                case 0x95 { // OP_SWAP6
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 6)
-                }
-                case 0x96 { // OP_SWAP7    
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 7)
-                }
-                case 0x97 { // OP_SWAP8
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 8)
-                }
-                case 0x98 { // OP_SWAP9
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 9)
-                }
-                case 0x99 { // OP_SWAP10   
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 10)
-                }
-                case 0x9A { // OP_SWAP11
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 11)
-                }
-                case 0x9B { // OP_SWAP12
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 12)
-                }
-                case 0x9C { // OP_SWAP13
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 13)
-                }
-                case 0x9D { // OP_SWAP14
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 14)
-                }
-                case 0x9E { // OP_SWAP15
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 15)
-                }
-                case 0x9F { // OP_SWAP16
-                    evmGasLeft := swapStackItem(sp, evmGasLeft, 16)
-                }
-                case 0xA0 { // OP_LOG0
-                    evmGasLeft := chargeGas(evmGasLeft, 375)
-            
-                    if isStatic {
-                        revertWithGas(evmGasLeft)
-                    }
-            
-                    let offset, size
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    size, sp := popStackItem(sp, evmGasLeft)
-            
-                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
-                    checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
-            
-                    // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
-                    let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
-                    evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
-            
-                    log0(add(offset, MEM_OFFSET_INNER()), size)
-                }
-                case 0xA1 { // OP_LOG1
-                    evmGasLeft := chargeGas(evmGasLeft, 375)
-            
-                    if isStatic {
-                        revertWithGas(evmGasLeft)
-                    }
-            
-                    let offset, size, topic1
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    size, sp := popStackItem(sp, evmGasLeft)
-                    topic1, sp := popStackItem(sp, evmGasLeft)
-            
-                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
-                    checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
-            
-                    // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
-                    let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
-                    dynamicGas := add(dynamicGas, 375)
-                    evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
-            
-                    log1(add(offset, MEM_OFFSET_INNER()), size, topic1)
-                }
-                case 0xA2 { // OP_LOG2
-                    evmGasLeft := chargeGas(evmGasLeft, 375)
-                    if isStatic {
-                        revertWithGas(evmGasLeft)
-                    }
-            
-                    let offset, size
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    size, sp := popStackItem(sp, evmGasLeft)
-            
-                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
-                    checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
-            
-                    // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
-                    let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
-                    dynamicGas := add(dynamicGas, 750)
-                    evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
-            
-                    {
-                        let topic1, topic2
-                        topic1, sp := popStackItem(sp, evmGasLeft)
-                        topic2, sp := popStackItem(sp, evmGasLeft)
-                        log2(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2)
-                    }
-                }
-                case 0xA3 { // OP_LOG3
-                    evmGasLeft := chargeGas(evmGasLeft, 375)
-            
-                    if isStatic {
-                        revertWithGas(evmGasLeft)
-                    }
-            
-                    let offset, size
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    size, sp := popStackItem(sp, evmGasLeft)
-            
-                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
-            
-                    checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
-            
-                    // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
-                    let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
-                    dynamicGas := add(dynamicGas, 1125)
-                    evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
-            
-                    {
-                        let topic1, topic2, topic3
-                        topic1, sp := popStackItem(sp, evmGasLeft)
-                        topic2, sp := popStackItem(sp, evmGasLeft)
-                        topic3, sp := popStackItem(sp, evmGasLeft)
-                        log3(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3)
-                    }     
-                }
-                case 0xA4 { // OP_LOG4
-                    evmGasLeft := chargeGas(evmGasLeft, 375)
-            
-                    if isStatic {
-                        revertWithGas(evmGasLeft)
-                    }
-            
-                    let offset, size
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    size, sp := popStackItem(sp, evmGasLeft)
-            
-                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
-                    checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
-            
-                    // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
-                    let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
-                    dynamicGas := add(dynamicGas, 1500)
-                    evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
-            
-                    {
-                        let topic1, topic2, topic3, topic4
-                        topic1, sp := popStackItem(sp, evmGasLeft)
-                        topic2, sp := popStackItem(sp, evmGasLeft)
-                        topic3, sp := popStackItem(sp, evmGasLeft)
-                        topic4, sp := popStackItem(sp, evmGasLeft)
-                        log4(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3, topic4)
-                    }     
-                }
-                case 0xF0 { // OP_CREATE
-                    evmGasLeft, sp := performCreate(evmGasLeft, sp, isStatic)
-                }
-                case 0xF1 { // OP_CALL
-                    evmGasLeft := chargeGas(evmGasLeft, 100)
-            
-                    let gasUsed
-            
-                    // A function was implemented in order to avoid stack depth errors.
-                    gasUsed, sp := performCall(sp, evmGasLeft, isStatic)
-            
-                    // Check if the following is ok
-                    evmGasLeft := chargeGas(evmGasLeft, gasUsed)
-                }
-                case 0xF3 { // OP_RETURN
-                    let offset,size
-            
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    size, sp := popStackItem(sp, evmGasLeft)
-            
-                    checkOverflow(offset,size, evmGasLeft)
-                    evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
-            
-                    returnLen := size
-                    checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
-                    returnOffset := add(MEM_OFFSET_INNER(), offset)
-                    break
-                }
-                case 0xF4 { // OP_DELEGATECALL
-                    evmGasLeft := chargeGas(evmGasLeft, 100)
-            
-                    let gasUsed
-                    sp, isStatic, gasUsed := delegateCall(sp, isStatic, evmGasLeft)
-            
-                    evmGasLeft := chargeGas(evmGasLeft, gasUsed)
-                }
-                case 0xF5 { // OP_CREATE2
-                    let result, addr
-                    evmGasLeft, sp, result, addr := performCreate2(evmGasLeft, sp, isStatic)
-                    switch result
-                    case 0 { sp := pushStackItem(sp, 0, evmGasLeft) }
-                    default { sp := pushStackItem(sp, addr, evmGasLeft) }
-                }
-                case 0xFA { // OP_STATICCALL
-                    evmGasLeft := chargeGas(evmGasLeft, 100)
-            
-                    let gasUsed
-                    gasUsed, sp := performStaticCall(sp,evmGasLeft)
-                    evmGasLeft := chargeGas(evmGasLeft,gasUsed)
-                }
-                case 0xFD { // OP_REVERT
-                    let offset,size
-            
-                    offset, sp := popStackItem(sp, evmGasLeft)
-                    size, sp := popStackItem(sp, evmGasLeft)
-            
-                    ensureAcceptableMemLocation(offset)
-                    ensureAcceptableMemLocation(size)
-                    evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
-            
-                    offset := add(offset, MEM_OFFSET_INNER())
-                    offset,size := addGasIfEvmRevert(isCallerEVM,offset,size,evmGasLeft)
-            
-                    revert(offset,size)
-                }
-                case 0xFE { // OP_INVALID
-                    evmGasLeft := 0
-            
-                    revertWithGas(evmGasLeft)
-                }
-                default {
-                    printString("INVALID OPCODE")
-                    printHex(opcode)
-                    revert(0, 0)
-                }
-            }
-            
-
-            if eq(isCallerEVM, 1) {
-                // Includes gas
-                returnOffset := sub(returnOffset, 32)
-                checkOverflow(returnLen, 32, evmGasLeft)
-                returnLen := add(returnLen, 32)
-
-                mstore(returnOffset, evmGasLeft)
-            }
-
+            let returnOffset, returnLen := $llvm_NoInline_llvm$_simulate(isCallerEVM, evmGasLeft, isStatic)
             return(returnOffset, returnLen)
         }
     }

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -670,6 +670,19 @@ object "EVMInterpreter" {
             originalValue := mload(32)
         }
         
+        function MAX_SYSTEM_CONTRACT_ADDR() -> ret {
+            ret := 0x000000000000000000000000000000000000ffff
+        }
+        
+        /// @dev Checks whether an address is an EOA (i.e. has not code deployed on it)
+        /// @param addr The address to check
+        function isEOA(addr) -> ret {
+            ret := 0
+            if gt(addr, MAX_SYSTEM_CONTRACT_ADDR()) {
+                ret := iszero(_getRawCodeHash(addr))
+            }
+        }
+        
         function getNewAddress(addr) -> newAddr {
             let digest, nonce, addressEncoded, nonceEncoded, nonceEncodedLength, listLength, listLengthEconded
         
@@ -1353,7 +1366,17 @@ object "EVMInterpreter" {
         
             _popEVMFrame()
         
-            incrementNonce(address())
+            switch result
+            case 1 {
+                incrementNonce(address())
+            }
+            default {
+                switch isEOA(address())
+                case 1 {
+                    incrementNonce(address())
+                }
+                default {}
+            }
         
             let back
         
@@ -3501,6 +3524,19 @@ object "EVMInterpreter" {
                 originalValue := mload(32)
             }
             
+            function MAX_SYSTEM_CONTRACT_ADDR() -> ret {
+                ret := 0x000000000000000000000000000000000000ffff
+            }
+            
+            /// @dev Checks whether an address is an EOA (i.e. has not code deployed on it)
+            /// @param addr The address to check
+            function isEOA(addr) -> ret {
+                ret := 0
+                if gt(addr, MAX_SYSTEM_CONTRACT_ADDR()) {
+                    ret := iszero(_getRawCodeHash(addr))
+                }
+            }
+            
             function getNewAddress(addr) -> newAddr {
                 let digest, nonce, addressEncoded, nonceEncoded, nonceEncodedLength, listLength, listLengthEconded
             
@@ -4184,7 +4220,17 @@ object "EVMInterpreter" {
             
                 _popEVMFrame()
             
-                incrementNonce(address())
+                switch result
+                case 1 {
+                    incrementNonce(address())
+                }
+                default {
+                    switch isEOA(address())
+                    case 1 {
+                        incrementNonce(address())
+                    }
+                    default {}
+                }
             
                 let back
             


### PR DESCRIPTION
# What ❔

This PR fixes some tests on era-compiler-tester that expected the nonce on EVM to start at 1, while we start it at 0.

It depends on https://github.com/lambdaclass/era-compiler-tester/pull/1
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
