### PR TITLE
[EVM-Equivalence-YUL] Fix overflow checks

### DIFF
--- a/system-contracts/SystemContractsHashes.json
+++ b/system-contracts/SystemContractsHashes.json
@@ -129,8 +129,8 @@
     "contractName": "EvmInterpreter",
     "bytecodePath": "contracts-preprocessed/artifacts/EvmInterpreter.yul.zbin",
     "sourceCodePath": "contracts-preprocessed/EvmInterpreter.yul",
-    "bytecodeHash": "0x01000cef160515b2631803991c1d49b6b44492406197fb6dc22a8cf05cebd5d5",
-    "sourceCodeHash": "0x6c1e3d4c2f94342792df4fc671a0929fbb2d5aba1b5e388c70f4dc1ee96cfa74"
+    "bytecodeHash": "0x01000cdf5bb7dd8a97faf231a5e1e20f2fe308d6f200c3295c6e3629547cc4a4",
+    "sourceCodeHash": "0xe1133c2af9e4fc38e845f7fcc23f3cbab37b857013f55b6e7e9bdea28f331c40"
   },
   {
     "contractName": "CodeOracle",

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -2994,8 +2994,6 @@ object "EVMInterpreter" {
                     offset, sp := popStackItemWithoutCheck(sp)
                     size, sp := popStackItemWithoutCheck(sp)
             
-                    ensureAcceptableMemLocation(offset)
-                    ensureAcceptableMemLocation(size)
                     checkOverflow(offset,size, evmGasLeft)
                     checkMemOverflowByOffset(add(offset, size), evmGasLeft)
                     evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
@@ -5962,8 +5960,6 @@ object "EVMInterpreter" {
                         offset, sp := popStackItemWithoutCheck(sp)
                         size, sp := popStackItemWithoutCheck(sp)
                 
-                        ensureAcceptableMemLocation(offset)
-                        ensureAcceptableMemLocation(size)
                         checkOverflow(offset,size, evmGasLeft)
                         checkMemOverflowByOffset(add(offset, size), evmGasLeft)
                         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -2966,7 +2966,8 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
             
                     returnLen := size
-                    checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
+                    
+                    // Don't check overflow here since previous checks are enough to ensure this is safe
                     returnOffset := add(MEM_OFFSET_INNER(), offset)
                     break
                 }
@@ -3006,7 +3007,8 @@ object "EVMInterpreter" {
                     checkMemOverflowByOffset(add(offset, size), evmGasLeft)
                     evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
             
-                    checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
+            
+                    // Don't check overflow here since previous checks are enough to ensure this is safe
                     offset := add(offset, MEM_OFFSET_INNER())
                     offset,size := addGasIfEvmRevert(isCallerEVM,offset,size,evmGasLeft)
             
@@ -5940,7 +5942,8 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
                 
                         returnLen := size
-                        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
+                        
+                        // Don't check overflow here since previous checks are enough to ensure this is safe
                         returnOffset := add(MEM_OFFSET_INNER(), offset)
                         break
                     }
@@ -5980,7 +5983,8 @@ object "EVMInterpreter" {
                         checkMemOverflowByOffset(add(offset, size), evmGasLeft)
                         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
                 
-                        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
+                
+                        // Don't check overflow here since previous checks are enough to ensure this is safe
                         offset := add(offset, MEM_OFFSET_INNER())
                         offset,size := addGasIfEvmRevert(isCallerEVM,offset,size,evmGasLeft)
                 

--- a/system-contracts/evm-interpreter/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/evm-interpreter/EvmInterpreterFunctions.template.yul
@@ -659,12 +659,6 @@ function getFarCallABI(
     ret := farCallAbi
 }
 
-function ensureAcceptableMemLocation(location) {
-    if gt(location,MAX_POSSIBLE_MEM()) {
-        revert(0,0) // Check if this is what's needed
-    }
-}
-
 function addGasIfEvmRevert(isCallerEVM,offset,size,evmGasLeft) -> newOffset,newSize {
     newOffset := offset
     newSize := size

--- a/system-contracts/evm-interpreter/EvmInterpreterLoop.template.yul
+++ b/system-contracts/evm-interpreter/EvmInterpreterLoop.template.yul
@@ -1406,7 +1406,8 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
 
         returnLen := size
-        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
+        
+        // Don't check overflow here since previous checks are enough to ensure this is safe
         returnOffset := add(MEM_OFFSET_INNER(), offset)
         break
     }
@@ -1446,7 +1447,8 @@ for { } true { } {
         checkMemOverflowByOffset(add(offset, size), evmGasLeft)
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
 
-        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
+
+        // Don't check overflow here since previous checks are enough to ensure this is safe
         offset := add(offset, MEM_OFFSET_INNER())
         offset,size := addGasIfEvmRevert(isCallerEVM,offset,size,evmGasLeft)
 

--- a/system-contracts/evm-interpreter/EvmInterpreterLoop.template.yul
+++ b/system-contracts/evm-interpreter/EvmInterpreterLoop.template.yul
@@ -1440,8 +1440,6 @@ for { } true { } {
         offset, sp := popStackItemWithoutCheck(sp)
         size, sp := popStackItemWithoutCheck(sp)
 
-        ensureAcceptableMemLocation(offset)
-        ensureAcceptableMemLocation(size)
         checkOverflow(offset,size, evmGasLeft)
         checkMemOverflowByOffset(add(offset, size), evmGasLeft)
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))

--- a/system-contracts/evm-interpreter/EvmInterpreterLoop.template.yul
+++ b/system-contracts/evm-interpreter/EvmInterpreterLoop.template.yul
@@ -410,13 +410,8 @@ for { } true { } {
         offset, sp := popStackItemWithoutCheck(sp)
         size, sp := popStackItemWithoutCheck(sp)
 
-        checkMultipleOverflow(offset,size,MEM_OFFSET_INNER(), evmGasLeft)
-        checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER(), evmGasLeft)
-
-        // TODO invalid?
-        if or(gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM()), gt(add(add(destOffset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM())) {
-            $llvm_AlwaysInline_llvm$_memsetToZero(add(destOffset, MEM_OFFSET_INNER()), size)
-        }
+        checkOverflow(destOffset, size, evmGasLeft)
+        checkMemOverflowByOffset(add(destOffset,size), evmGasLeft)
 
         // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
         // minimum_word_size = (size + 31) / 32
@@ -454,6 +449,7 @@ for { } true { } {
         offset := add(add(offset, BYTECODE_OFFSET()), 32)
 
         checkOverflow(dst,len, evmGasLeft)
+        checkOverflow(offset,len, evmGasLeft)
         checkMemOverflow(add(dst, len), evmGasLeft)
         // Check bytecode overflow
         if gt(add(offset, len), sub(MEM_OFFSET(), 1)) {
@@ -810,7 +806,8 @@ for { } true { } {
         offset, sp := popStackItemWithoutCheck(sp)
         size, sp := popStackItemWithoutCheck(sp)
 
-        // TODO overflow checks
+        checkOverflow(offset, size, evmGasLeft)
+        checkOverflow(destOffset, size, evmGasLeft)
         checkMemOverflowByOffset(add(offset, size), evmGasLeft)
         checkMemOverflowByOffset(add(destOffset, size), evmGasLeft)
 
@@ -1403,6 +1400,7 @@ for { } true { } {
         size, sp := popStackItemWithoutCheck(sp)
 
         checkOverflow(offset,size, evmGasLeft)
+        checkMemOverflowByOffset(add(offset,size), evmGasLeft)
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
 
         returnLen := size
@@ -1442,11 +1440,13 @@ for { } true { } {
         offset, sp := popStackItemWithoutCheck(sp)
         size, sp := popStackItemWithoutCheck(sp)
 
-        // TODO invalid?
         ensureAcceptableMemLocation(offset)
         ensureAcceptableMemLocation(size)
+        checkOverflow(offset,size, evmGasLeft)
+        checkMemOverflowByOffset(add(offset, size), evmGasLeft)
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
 
+        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
         offset := add(offset, MEM_OFFSET_INNER())
         offset,size := addGasIfEvmRevert(isCallerEVM,offset,size,evmGasLeft)
 


### PR DESCRIPTION
# What ❔

This PR removes the // todo invalid comments that needed fixes

In revert opcode:
Changed the wrong checks, mimicking the ones in return opcode.

In calldatacopy:
Removed the overflow checks, since it would never fall into the second one, which is the correct one.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
