### PR TITLE
Revert fetch deployed code len optimization

### DIFF
--- a/system-contracts/SystemContractsHashes.json
+++ b/system-contracts/SystemContractsHashes.json
@@ -129,8 +129,8 @@
     "contractName": "EvmInterpreter",
     "bytecodePath": "contracts-preprocessed/artifacts/EvmInterpreter.yul.zbin",
     "sourceCodePath": "contracts-preprocessed/EvmInterpreter.yul",
-    "bytecodeHash": "0x01000ccb740e2345754450eda583f59b31a346920a22f968dfcfc63feae303ee",
-    "sourceCodeHash": "0xfc91734d4d37538b19c94be0da51364edd4f6664f0fee383cc2e3b5eeb95336a"
+    "bytecodeHash": "0x01000cef160515b2631803991c1d49b6b44492406197fb6dc22a8cf05cebd5d5",
+    "sourceCodeHash": "0x6c1e3d4c2f94342792df4fc671a0929fbb2d5aba1b5e388c70f4dc1ee96cfa74"
   },
   {
     "contractName": "CodeOracle",

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -346,16 +346,22 @@ object "EVMInterpreter" {
         function _fetchDeployedCodeLen(addr) -> codeLen {
             let codeHash := _getRawCodeHash(addr)
         
-            switch shr(248, codeHash)
+            mstore(0, codeHash)
+        
+            let success := staticcall(gas(), CODE_ORACLE_SYSTEM_CONTRACT(), 0, 32, 0, 0)
+        
+            switch iszero(success)
             case 1 {
-                // EraVM
-                let codeLengthInWords := and(shr(224, codeHash), 0xffff)
-                codeLen := shl(5, codeLengthInWords) // codeLengthInWords * 32
+                // The code oracle call can only fail in the case where the contract
+                // we are querying is the current one executing and it has not yet been
+                // deployed, i.e., if someone calls codesize (or extcodesize(address()))
+                // inside the constructor. In that case, code length is zero.
+                codeLen := 0
             }
-            case 2 {
-                // EVM
-                let codeLengthInBytes := and(shr(224, codeHash), 0xffff)
-                codeLen := codeLengthInBytes
+            default {
+                // The first word is the true length of the bytecode
+                returndatacopy(0, 0, 32)
+                codeLen := mload(0)
             }
         }
         
@@ -2040,7 +2046,9 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, 2500)
                     }
             
-                    sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr))
+                    switch _isEVM(addr) 
+                        case 0  { sp := pushStackItemWithoutCheck(sp, extcodesize(addr)) }
+                        default { sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr)) }
                     ip := add(ip, 1)
                 }
                 case 0x3C { // OP_EXTCODECOPY
@@ -3320,16 +3328,22 @@ object "EVMInterpreter" {
             function _fetchDeployedCodeLen(addr) -> codeLen {
                 let codeHash := _getRawCodeHash(addr)
             
-                switch shr(248, codeHash)
+                mstore(0, codeHash)
+            
+                let success := staticcall(gas(), CODE_ORACLE_SYSTEM_CONTRACT(), 0, 32, 0, 0)
+            
+                switch iszero(success)
                 case 1 {
-                    // EraVM
-                    let codeLengthInWords := and(shr(224, codeHash), 0xffff)
-                    codeLen := shl(5, codeLengthInWords) // codeLengthInWords * 32
+                    // The code oracle call can only fail in the case where the contract
+                    // we are querying is the current one executing and it has not yet been
+                    // deployed, i.e., if someone calls codesize (or extcodesize(address()))
+                    // inside the constructor. In that case, code length is zero.
+                    codeLen := 0
                 }
-                case 2 {
-                    // EVM
-                    let codeLengthInBytes := and(shr(224, codeHash), 0xffff)
-                    codeLen := codeLengthInBytes
+                default {
+                    // The first word is the true length of the bytecode
+                    returndatacopy(0, 0, 32)
+                    codeLen := mload(0)
                 }
             }
             
@@ -5014,7 +5028,9 @@ object "EVMInterpreter" {
                             evmGasLeft := chargeGas(evmGasLeft, 2500)
                         }
                 
-                        sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr))
+                        switch _isEVM(addr) 
+                            case 0  { sp := pushStackItemWithoutCheck(sp, extcodesize(addr)) }
+                            default { sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr)) }
                         ip := add(ip, 1)
                     }
                     case 0x3C { // OP_EXTCODECOPY

--- a/system-contracts/evm-interpreter/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/evm-interpreter/EvmInterpreterFunctions.template.yul
@@ -264,16 +264,22 @@ function _fetchDeployedCodeWithDest(addr, _offset, _len, dest) -> codeLen {
 function _fetchDeployedCodeLen(addr) -> codeLen {
     let codeHash := _getRawCodeHash(addr)
 
-    switch shr(248, codeHash)
+    mstore(0, codeHash)
+
+    let success := staticcall(gas(), CODE_ORACLE_SYSTEM_CONTRACT(), 0, 32, 0, 0)
+
+    switch iszero(success)
     case 1 {
-        // EraVM
-        let codeLengthInWords := and(shr(224, codeHash), 0xffff)
-        codeLen := shl(5, codeLengthInWords) // codeLengthInWords * 32
+        // The code oracle call can only fail in the case where the contract
+        // we are querying is the current one executing and it has not yet been
+        // deployed, i.e., if someone calls codesize (or extcodesize(address()))
+        // inside the constructor. In that case, code length is zero.
+        codeLen := 0
     }
-    case 2 {
-        // EVM
-        let codeLengthInBytes := and(shr(224, codeHash), 0xffff)
-        codeLen := codeLengthInBytes
+    default {
+        // The first word is the true length of the bytecode
+        returndatacopy(0, 0, 32)
+        codeLen := mload(0)
     }
 }
 

--- a/system-contracts/evm-interpreter/EvmInterpreterLoop.template.yul
+++ b/system-contracts/evm-interpreter/EvmInterpreterLoop.template.yul
@@ -480,7 +480,9 @@ for { } true { } {
             evmGasLeft := chargeGas(evmGasLeft, 2500)
         }
 
-        sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr))
+        switch _isEVM(addr) 
+            case 0  { sp := pushStackItemWithoutCheck(sp, extcodesize(addr)) }
+            default { sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr)) }
         ip := add(ip, 1)
     }
     case 0x3C { // OP_EXTCODECOPY


### PR DESCRIPTION
# What ❔

Reverts [this PR](https://github.com/matter-labs/era-contracts/pull/752) as a few semantic tests were not passing with it, due to some edge cases (the "real" length of an EVM contract is not the one in the code hash because of padding rules)

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
