### PR TITLE
feat: Optimize EvmGasManager further

### DIFF
--- a/system-contracts/contracts/AccountCodeStorage.sol
+++ b/system-contracts/contracts/AccountCodeStorage.sol
@@ -115,8 +115,7 @@ contract AccountCodeStorage is IAccountCodeStorage {
         // so set `keccak256("")` as a code hash. The EVM has the same behavior.
         else if (Utils.isContractConstructing(codeHash)) {
             codeHash = EMPTY_STRING_KECCAK;
-        } 
-        else if (Utils.isCodeHashEVM(codeHash)) {
+        } else if (Utils.isCodeHashEVM(codeHash)) {
             codeHash = DEPLOYER_SYSTEM_CONTRACT.evmCodeHash(account);
         }
 

--- a/system-contracts/contracts/EvmGasManager.sol
+++ b/system-contracts/contracts/EvmGasManager.sol
@@ -4,7 +4,7 @@
 
 pragma solidity ^0.8.0;
 
-import "./libraries/Utils.sol";
+import {Utils} from "./libraries/Utils.sol";
 
 import {ACCOUNT_CODE_STORAGE_SYSTEM_CONTRACT} from "./Constants.sol";
 import {SystemContractHelper} from "./libraries/SystemContractHelper.sol";
@@ -12,16 +12,19 @@ import {SystemContractHelper} from "./libraries/SystemContractHelper.sol";
 // We consider all the contracts (including system ones) as warm.
 uint160 constant PRECOMPILES_END = 0xffff;
 
-uint256 constant INF_PASS_GAS = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
-
 // Transient storage prefixes
 uint256 constant IS_ACCOUNT_EVM_PREFIX = 1 << 255;
 uint256 constant IS_ACCOUNT_WARM_PREFIX = 1 << 254;
 uint256 constant IS_SLOT_WARM_PREFIX = 1 << 253;
-uint256 constant EVM_STACK_SLOT = 2;
+
+uint256 constant EVM_GAS_SLOT = 4;
+uint256 constant EVM_AUX_DATA_SLOT = 5;
+uint256 constant EVM_ACTIVE_FRAME_FLAG = 1 << 1;
 
 contract EvmGasManager {
     modifier onlySystemEvm() {
+        require(SystemContractHelper.isSystemCall(), "This method requires system call flag");
+
         // cache use is safe since we do not support SELFDESTRUCT
         uint256 transient_slot = IS_ACCOUNT_EVM_PREFIX | uint256(uint160(msg.sender));
         bool isEVM;
@@ -42,7 +45,6 @@ contract EvmGasManager {
         }
 
         require(isEVM, "only system evm");
-        require(SystemContractHelper.isSystemCall(), "This method requires system call flag");
         _;
     }
 
@@ -51,17 +53,17 @@ contract EvmGasManager {
     */
     function warmAccount(address account) external payable onlySystemEvm returns (bool wasWarm) {
         if (uint160(account) < PRECOMPILES_END) return true;
-
         uint256 transient_slot = IS_ACCOUNT_WARM_PREFIX | uint256(uint160(account));
 
         assembly {
             wasWarm := tload(transient_slot)
-        }
 
-        if (!wasWarm) {
-            assembly {
+            if iszero(wasWarm) {
                 tstore(transient_slot, 1)
             }
+
+            mstore(0x0, wasWarm)
+            return(0x0, 0x20)
         }
     }
 
@@ -72,10 +74,10 @@ contract EvmGasManager {
             mstore(0, prefix)
             mstore(0x20, _slot)
             transient_slot := keccak256(0, 64)
-        }
-
-        assembly {
             isWarm := tload(transient_slot)
+
+            mstore(0x0, isWarm)
+            return(0x0, 0x20)
         }
     }
 
@@ -89,69 +91,55 @@ contract EvmGasManager {
             mstore(0, prefix)
             mstore(0x20, _slot)
             transient_slot := keccak256(0, 64)
-        }
 
-        assembly {
             isWarm := tload(transient_slot)
-        }
 
-        if (isWarm) {
-            assembly {
-                originalValue := tload(add(transient_slot, 1))
-            }
-        } else {
-            originalValue = _currentValue;
-
-            assembly {
+            switch isWarm
+            case 0 {
+                originalValue := _currentValue
                 tstore(transient_slot, 1)
                 tstore(add(transient_slot, 1), originalValue)
             }
+            default {
+                originalValue := tload(add(transient_slot, 1))
+            }
+
+            mstore(0x0, isWarm)
+            mstore(0x20, originalValue)
+            return(0x0, 0x40)
         }
     }
 
     /*
-
     The flow is the following:
 
     When conducting call:
         1. caller calls to an EVM contract pushEVMFrame with the corresponding gas
-        2. callee calls consumeEvmFrame to get the gas and determine if a call is static
-        3. calleer calls popEVMFrame to remove the frame
+        2. callee calls consumeEvmFrame to get the gas and determine if a call is static, frame is marked as used
     */
 
     function pushEVMFrame(uint256 passGas, bool isStatic) external onlySystemEvm {
         assembly {
-            let stackDepth := add(tload(EVM_STACK_SLOT), 1)
-            tstore(EVM_STACK_SLOT, stackDepth)
-            let stackPointer := add(EVM_STACK_SLOT, mul(2, stackDepth))
-            tstore(stackPointer, passGas)
-            tstore(add(stackPointer, 1), isStatic)
+            tstore(EVM_GAS_SLOT, passGas)
+            tstore(EVM_AUX_DATA_SLOT, or(isStatic, EVM_ACTIVE_FRAME_FLAG))
         }
     }
 
-    function consumeEvmFrame() external onlySystemEvm returns (uint256 passGas, bool isStatic) {
-        uint256 stackDepth;
+    function consumeEvmFrame() external onlySystemEvm returns (uint256 passGas, uint256 auxDataRes) {
         assembly {
-            stackDepth := tload(EVM_STACK_SLOT)
-        }
-        if (stackDepth == 0) return (INF_PASS_GAS, false);
+            let auxData := tload(EVM_AUX_DATA_SLOT)
+            let isFrameActive := and(auxData, EVM_ACTIVE_FRAME_FLAG)
 
-        assembly {
-            let stackPointer := add(EVM_STACK_SLOT, mul(2, stackDepth))
-            passGas := tload(stackPointer)
-            isStatic := tload(add(stackPointer, 1))
-            tstore(stackPointer, INF_PASS_GAS) // mark as consumed
-        }
-    }
+            if isFrameActive {
+                passGas := tload(EVM_GAS_SLOT)
+                auxDataRes := auxData
 
-    function popEVMFrame() external onlySystemEvm {
-        uint256 stackDepth;
-        assembly {
-            stackDepth := tload(EVM_STACK_SLOT)
-        }
-        require(stackDepth != 0);
-        assembly {
-            tstore(EVM_STACK_SLOT, sub(stackDepth, 1))
+                tstore(EVM_AUX_DATA_SLOT, 0) // mark as consumed
+            }
+
+            mstore(0x0, passGas)
+            mstore(0x20, auxDataRes)
+            return(0x0, 0x40)
         }
     }
 }

--- a/system-contracts/contracts/EvmGasManager.sol
+++ b/system-contracts/contracts/EvmGasManager.sol
@@ -118,14 +118,14 @@ contract EvmGasManager {
         2. callee calls consumeEvmFrame to get the gas and determine if a call is static, frame is marked as used
     */
 
-    function pushEVMFrame(uint256 passGas, bool isStatic) external onlySystemEvm {
+    function pushEVMFrame(uint256 passGas, bool isStatic) external payable onlySystemEvm {
         assembly {
             tstore(EVM_GAS_SLOT, passGas)
             tstore(EVM_AUX_DATA_SLOT, or(isStatic, EVM_ACTIVE_FRAME_FLAG))
         }
     }
 
-    function consumeEvmFrame() external onlySystemEvm returns (uint256 passGas, uint256 auxDataRes) {
+    function consumeEvmFrame() external payable onlySystemEvm returns (uint256 passGas, uint256 auxDataRes) {
         assembly {
             let auxData := tload(EVM_AUX_DATA_SLOT)
             let isFrameActive := and(auxData, EVM_ACTIVE_FRAME_FLAG)

--- a/system-contracts/contracts/EvmGasManager.sol
+++ b/system-contracts/contracts/EvmGasManager.sol
@@ -43,14 +43,14 @@ contract EvmGasManager {
                 // function getRawCodeHash(address _address) public view returns (bytes32 codeHash)
                 mstore(0, 0x4DE2E46800000000000000000000000000000000000000000000000000000000)
                 mstore(4, _sender)
-            
+
                 let success := staticcall(gas(), to, 0, 36, 0, 32)
-            
+
                 if iszero(success) {
                     // This error should never happen
                     revert(0, 0)
                 }
-            
+
                 rawCodeHash := mload(0)
             }
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -368,7 +368,7 @@ object "EVMInterpreter" {
         }
         
         function consumeEvmFrame() -> passGas, isStatic, callerEVM {
-            // function consumeEvmFrame() external returns (uint256 passGas, bool isStatic)
+            // function consumeEvmFrame() external returns (uint256 passGas, uint256 auxDataRes)
             mstore(0, 0x04C14E9E00000000000000000000000000000000000000000000000000000000)
         
             let farCallAbi := getFarCallABI(
@@ -393,11 +393,12 @@ object "EVMInterpreter" {
         
             returndatacopy(0,0,64)
         
-            passGas := mload(0)
-            isStatic := mload(32)
+            let auxData := mload(32)
+            callerEVM := gt(auxData, 1)
         
-            if iszero(eq(passGas, INF_PASS_GAS())) {
-                callerEVM := true
+            if callerEVM {
+                isStatic := and(auxData, 1)
+                passGas := mload(0)
             }
         }
         
@@ -774,33 +775,6 @@ object "EVMInterpreter" {
             }
         }
         
-        function _popEVMFrame() {
-            // function popEVMFrame() external
-        
-             let farCallAbi := getFarCallABI(
-                0,
-                0,
-                0,
-                4,
-                gas(),
-                // Only rollup is supported for now
-                0,
-                0,
-                0,
-                1
-            )
-        
-            let to := EVM_GAS_MANAGER_CONTRACT()
-        
-            mstore(0, 0xE467D2F000000000000000000000000000000000000000000000000000000000)
-        
-            let success := verbatim_6i_1o("system_call", to, farCallAbi, 0, 0, 0, 0)
-            if iszero(success) {
-                // This error should never happen
-                revert(0, 0)
-            }
-        }
-        
         // Each evm gas is 5 zkEVM one
         function GAS_DIVISOR() -> gas_div { gas_div := 5 }
         function EVM_GAS_STIPEND() -> gas_stipend { gas_stipend := shl(30, 1) } // 1 << 30
@@ -941,7 +915,6 @@ object "EVMInterpreter" {
                 success := staticcall(gasToPass, addr, add(MEM_OFFSET_INNER(), argsOffset), argsSize, 0, 0)
         
                 frameGasLeft := _saveReturndataAfterEVMCall(add(MEM_OFFSET_INNER(), retOffset), retSize)
-                _popEVMFrame()
             }
         
             let precompileCost := getGasForPrecompiles(addr, argsOffset, argsSize)
@@ -998,7 +971,6 @@ object "EVMInterpreter" {
                     _pushEVMFrame(gasToPassNew, isStatic)
                     success := call(EVM_GAS_STIPEND(), addr, value, argsOffset, argsSize, 0, 0)
                     frameGasLeft := _saveReturndataAfterEVMCall(retOffset, retSize)
-                    _popEVMFrame()
                 }
             }
             default {
@@ -1139,8 +1111,6 @@ object "EVMInterpreter" {
         
             let frameGasLeft := _saveReturndataAfterEVMCall(add(MEM_OFFSET_INNER(), retOffset), retSize)
         
-            _popEVMFrame()
-        
             let precompileCost := getGasForPrecompiles(addr, argsOffset, argsSize)
             switch iszero(precompileCost)
             case 1 {
@@ -1182,7 +1152,6 @@ object "EVMInterpreter" {
                 success := staticcall(EVM_GAS_STIPEND(), _callee, _inputOffset, _inputLen, 0, 0)
         
                 _gasLeft := _saveReturndataAfterEVMCall(_outputOffset, _outputLen)
-                _popEVMFrame()
             }
         }
         
@@ -1271,8 +1240,6 @@ object "EVMInterpreter" {
         
             let gasUsed := sub(gasForTheCall, gasLeft)
             evmGasLeft := chargeGas(evmGasLeftOld, gasUsed)
-        
-            _popEVMFrame()
         
             let back
         
@@ -3234,7 +3201,7 @@ object "EVMInterpreter" {
             }
             
             function consumeEvmFrame() -> passGas, isStatic, callerEVM {
-                // function consumeEvmFrame() external returns (uint256 passGas, bool isStatic)
+                // function consumeEvmFrame() external returns (uint256 passGas, uint256 auxDataRes)
                 mstore(0, 0x04C14E9E00000000000000000000000000000000000000000000000000000000)
             
                 let farCallAbi := getFarCallABI(
@@ -3259,11 +3226,12 @@ object "EVMInterpreter" {
             
                 returndatacopy(0,0,64)
             
-                passGas := mload(0)
-                isStatic := mload(32)
+                let auxData := mload(32)
+                callerEVM := gt(auxData, 1)
             
-                if iszero(eq(passGas, INF_PASS_GAS())) {
-                    callerEVM := true
+                if callerEVM {
+                    isStatic := and(auxData, 1)
+                    passGas := mload(0)
                 }
             }
             
@@ -3640,33 +3608,6 @@ object "EVMInterpreter" {
                 }
             }
             
-            function _popEVMFrame() {
-                // function popEVMFrame() external
-            
-                 let farCallAbi := getFarCallABI(
-                    0,
-                    0,
-                    0,
-                    4,
-                    gas(),
-                    // Only rollup is supported for now
-                    0,
-                    0,
-                    0,
-                    1
-                )
-            
-                let to := EVM_GAS_MANAGER_CONTRACT()
-            
-                mstore(0, 0xE467D2F000000000000000000000000000000000000000000000000000000000)
-            
-                let success := verbatim_6i_1o("system_call", to, farCallAbi, 0, 0, 0, 0)
-                if iszero(success) {
-                    // This error should never happen
-                    revert(0, 0)
-                }
-            }
-            
             // Each evm gas is 5 zkEVM one
             function GAS_DIVISOR() -> gas_div { gas_div := 5 }
             function EVM_GAS_STIPEND() -> gas_stipend { gas_stipend := shl(30, 1) } // 1 << 30
@@ -3807,7 +3748,6 @@ object "EVMInterpreter" {
                     success := staticcall(gasToPass, addr, add(MEM_OFFSET_INNER(), argsOffset), argsSize, 0, 0)
             
                     frameGasLeft := _saveReturndataAfterEVMCall(add(MEM_OFFSET_INNER(), retOffset), retSize)
-                    _popEVMFrame()
                 }
             
                 let precompileCost := getGasForPrecompiles(addr, argsOffset, argsSize)
@@ -3864,7 +3804,6 @@ object "EVMInterpreter" {
                         _pushEVMFrame(gasToPassNew, isStatic)
                         success := call(EVM_GAS_STIPEND(), addr, value, argsOffset, argsSize, 0, 0)
                         frameGasLeft := _saveReturndataAfterEVMCall(retOffset, retSize)
-                        _popEVMFrame()
                     }
                 }
                 default {
@@ -4005,8 +3944,6 @@ object "EVMInterpreter" {
             
                 let frameGasLeft := _saveReturndataAfterEVMCall(add(MEM_OFFSET_INNER(), retOffset), retSize)
             
-                _popEVMFrame()
-            
                 let precompileCost := getGasForPrecompiles(addr, argsOffset, argsSize)
                 switch iszero(precompileCost)
                 case 1 {
@@ -4048,7 +3985,6 @@ object "EVMInterpreter" {
                     success := staticcall(EVM_GAS_STIPEND(), _callee, _inputOffset, _inputLen, 0, 0)
             
                     _gasLeft := _saveReturndataAfterEVMCall(_outputOffset, _outputLen)
-                    _popEVMFrame()
                 }
             }
             
@@ -4137,8 +4073,6 @@ object "EVMInterpreter" {
             
                 let gasUsed := sub(gasForTheCall, gasLeft)
                 evmGasLeft := chargeGas(evmGasLeftOld, gasUsed)
-            
-                _popEVMFrame()
             
                 let back
             

--- a/system-contracts/contracts/SystemContractErrors.sol
+++ b/system-contracts/contracts/SystemContractErrors.sol
@@ -6,6 +6,8 @@ pragma solidity ^0.8.20;
 error AddressHasNoCode(address);
 // 0xefce78c7
 error CallerMustBeBootloader();
+// 0xbe4bf9e4
+error CallerMustBeEvmContract();
 // 0xb7549616
 error CallerMustBeForceDeployer();
 // 0x9eedbd2b

--- a/system-contracts/contracts/interfaces/IEvmGasManager.sol
+++ b/system-contracts/contracts/interfaces/IEvmGasManager.sol
@@ -8,7 +8,7 @@ interface IEvmGasManager {
 
     function warmSlot(uint256 _slot, uint256 _currentValue) external payable returns (bool, uint256);
 
-    function pushEVMFrame(uint256 _passGas, bool _isStatic) external;
+    function pushEVMFrame(uint256 _passGas, bool _isStatic) external payable;
 
-    function consumeEvmFrame() external returns (uint256 passGas, uint256 auxData);
+    function consumeEvmFrame() external payable returns (uint256 passGas, uint256 auxData);
 }

--- a/system-contracts/contracts/interfaces/IEvmGasManager.sol
+++ b/system-contracts/contracts/interfaces/IEvmGasManager.sol
@@ -10,7 +10,5 @@ interface IEvmGasManager {
 
     function pushEVMFrame(uint256 _passGas, bool _isStatic) external;
 
-    function consumeEvmFrame() external returns (uint256 passGas, bool isStatic);
-
-    function popEVMFrame() external;
+    function consumeEvmFrame() external returns (uint256 passGas, uint256 auxData);
 }


### PR DESCRIPTION
# What ❔

1. We can remove `popEVMFrame` function since we are using transient storage
2. Manual `return` in assembly block is cheaper for some reason

This pull request changes the structure of transient storage in EvmGasManager, so it will require small chang in the compiler tester.

Observed benchmark result: 
```
╔═╡ Size (-%) ╞═════╡ EVMInterpreter M3B3 ╞═╗
║ Best                                0.000 ║
║ Worst                               0.000 ║
║ Total                                 NaN ║
╠═╡ Cycles (-%) ╞═══╡ EVMInterpreter M3B3 ╞═╣
║ Best                                8.849 ║
║ Worst                               0.000 ║
║ Total                               1.672 ║
╠═╡ Ergs (-%) ╞═════╡ EVMInterpreter M3B3 ╞═╣
║ Best                                1.275 ║
║ Worst                               0.000 ║
║ Total                               0.632 ║

╠═╡ Ergs/gas (-%) ╞═╡ EVMInterpreter M3B3 ╞═╣
║ BALANCE                             1.639 ║
║ EXTCODESIZE                         0.736 ║
║ EXTCODECOPY                         0.723 ║
║ EXTCODEHASH                         0.559 ║
║ SLOAD                               0.749 ║
║ SSTORE                              1.467 ║
║ CALL                                1.315 ║
║ STATICCALL                          1.339 ║
║ DELEGATECALL                        1.316 ║
║ CREATE                              0.458 ║
║ CREATE2                             0.507 ║
╚═══════════════════════════════════════════╝
```

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
