### PR TITLE
fix: Implement short term fix for memory overflow in return

### DIFF
--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -2852,8 +2852,9 @@ object "EVMInterpreter" {
                     size, sp := popStackItemWithoutCheck(sp)
             
                     checkOverflow(offset,size, evmGasLeft)
-                    checkMemOverflowByOffset(add(offset,size), evmGasLeft)
                     evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
+            
+                    checkMemOverflowByOffset(add(offset,size), evmGasLeft)
             
                     returnLen := size
                     
@@ -5718,8 +5719,9 @@ object "EVMInterpreter" {
                         size, sp := popStackItemWithoutCheck(sp)
                 
                         checkOverflow(offset,size, evmGasLeft)
-                        checkMemOverflowByOffset(add(offset,size), evmGasLeft)
                         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
+                
+                        checkMemOverflowByOffset(add(offset,size), evmGasLeft)
                 
                         returnLen := size
                         

--- a/system-contracts/evm-interpreter/EvmInterpreterLoop.template.yul
+++ b/system-contracts/evm-interpreter/EvmInterpreterLoop.template.yul
@@ -1402,8 +1402,9 @@ for { } true { } {
         size, sp := popStackItemWithoutCheck(sp)
 
         checkOverflow(offset,size, evmGasLeft)
-        checkMemOverflowByOffset(add(offset,size), evmGasLeft)
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
+
+        checkMemOverflowByOffset(add(offset,size), evmGasLeft)
 
         returnLen := size
         


### PR DESCRIPTION
# What ❔

We have limited memory size, but some test rely on out-of-gas error produced by extremely huge memory growth. I will probably change the whole memory limits logic in the following pull requests

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
